### PR TITLE
Fix nodes disappearing after applying model linker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ Thumbs.db
 *.bak
 *.cache
 
+# Project data
+/data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ComfyUI Model Linker is a ComfyUI extension that helps users relink missing models in workflows. It scans workflow nodes for model references that no longer exist on disk, uses fuzzy matching (via `difflib.SequenceMatcher`) to suggest replacements, and remembers user selections as persistent overrides.
+
+This is **not** a custom node — it provides no `NODE_CLASS_MAPPINGS`. It registers API routes on `PromptServer` and loads a web UI via `WEB_DIRECTORY`.
+
+## Development Environment
+
+- **Python >=3.8**, no external dependencies beyond ComfyUI's own (aiohttp, folder_paths, server)
+- **JavaScript**: ES6 modules loaded by ComfyUI from `web/`
+- **Activate venv**: `call c:\ComfyUI\.venv\Scripts\activate`
+- **No test suite, no linter, no build step** — the extension is loaded directly by ComfyUI at startup
+- **To test changes**: restart ComfyUI (Python changes) or hard-refresh the browser (JS changes)
+
+## Architecture
+
+### Data Flow
+```
+Frontend (linker.js) → POST /model_linker/analyze → core/linker.py
+  → workflow_analyzer.py extracts model refs from all nodes (including subgraphs)
+  → scanner.py finds available models via ComfyUI's folder_paths
+  → matcher.py fuzzy-matches missing models to available ones
+  → overrides.py checks for saved user preferences
+  → Returns missing models with ranked suggestions to frontend
+
+Frontend → POST /model_linker/resolve → core/linker.py
+  → workflow_updater.py patches the workflow JSON
+  → overrides.py persists user selections to data/overrides.json
+```
+
+### Key Modules
+
+| Module | Responsibility |
+|---|---|
+| `__init__.py` | Extension entry point; registers 7 aiohttp API routes on `PromptServer` |
+| `core/linker.py` | High-level API: `analyze_and_find_matches()`, `apply_resolution()` |
+| `core/scanner.py` | Discovers model files using ComfyUI's `folder_paths` |
+| `core/matcher.py` | Fuzzy matching with filename normalization (removes extensions, normalizes separators) |
+| `core/workflow_analyzer.py` | Extracts model references from workflow JSON, handles subgraph definitions |
+| `core/workflow_updater.py` | Patches `widgets_values` in workflow nodes, supports subgraph nodes |
+| `core/overrides.py` | CRUD for `data/overrides.json` — persistent user model selections |
+| `web/linker.js` | Full frontend: modal dialog, toolbar button, model search/dropdown, overrides manager |
+
+### API Routes
+
+All routes are prefixed `/model_linker/`:
+- `POST /analyze` — analyze workflow for missing models
+- `POST /resolve` — apply selected resolutions to workflow
+- `GET /models` — list all available models
+- `GET /overrides` — get saved overrides
+- `POST /overrides/delete` — delete single override by key
+- `POST /overrides/clear` — clear all overrides
+- `POST /overrides/replace` — replace entire overrides document
+
+## Critical Conventions
+
+### Path Handling (Windows/Unix compatibility)
+- **Always use `os.path` methods** — never hardcode separators or normalize to forward slashes
+- ComfyUI uses OS-native separators; the extension must match this behavior
+- Model deduplication compares absolute paths via `os.path.normpath()` to detect symlink duplicates
+- Filename splitting uses regex `[/\\]` to handle both separators in stored paths
+
+### Fuzzy Matching
+- Filenames are normalized: lowercase, extensions removed, `_-` converted to spaces
+- Scores are capped at 0.999 for non-exact matches to distinguish from true 100% matches
+- Override matches get 99-100% confidence to appear at the top
+- Minimum threshold is 70% confidence
+
+### Frontend (linker.js)
+- Uses ComfyUI's `$el()` helper for DOM creation, not raw HTML
+- CSS is scoped with specific IDs/classes prefixed `model-linker-` to avoid ComfyUI style conflicts
+- Modal position/size persists via `localStorage`
+- Imports from ComfyUI relative paths: `../../scripts/app.js`, `../../scripts/api.js`, `../../scripts/ui.js`
+
+### Overrides Persistence
+- Stored at `data/overrides.json` (gitignored)
+- Format: `{version: 1, mappings: [{key: "category:normalized_name", path: "...", ...}]}`
+- Keys are `category:normalized_filename` for category-specific lookup

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ https://github.com/user-attachments/assets/fedf3645-aa66-49f7-b01d-8c3b5127faf4
 - Updates workflow JSON in UI/memory (user saves themselves)
 - Supports all node types
 - Optional auto-resolve for 100% confidence matches
+- Remembers manual selections: when you pick a replacement for a non-100% match, your choice is saved and shown as a perfect match next time
+- Dropdown with all models and search box to quickly pick the correct file
 
 ## Installation
 
@@ -26,8 +28,9 @@ https://github.com/user-attachments/assets/fedf3645-aa66-49f7-b01d-8c3b5127faf4
 1. Open a workflow with missing models
 2. Click the "🔗 — Model Linker" button in ComfyUI's top menu bar
 3. Review missing models and their suggested matches 
-4. Click "Resolve" for individual models or "Auto-Resolve 100% Matches" for perfect matches
-5. Save your workflow when ready
+4. Select replacements for individual models (via suggestion buttons or full model dropdown with search)
+5. Click "Apply Selected" to relink queued selections, or use "Auto-Resolve 100% Matches" for perfect matches
+6. Save your workflow when ready
 
 ## Features
 
@@ -35,4 +38,5 @@ https://github.com/user-attachments/assets/fedf3645-aa66-49f7-b01d-8c3b5127faf4
 - **Smart Matching**: Shows 100% confidence matches when available, otherwise shows best matches (â‰¥70% confidence)
 - **Fuzzy Matching**: Uses intelligent similarity scoring to find model files even with different naming
 - **Auto-Resolve**: One-click resolution for all perfect matches
+ - **Learned Overrides**: Your manual picks are persisted and reused automatically
 

--- a/__init__.py
+++ b/__init__.py
@@ -126,10 +126,20 @@ class ModelLinkerExtension:
                     # Persist user choices as overrides (so next time we know the correct match)
                     try:
                         # helper to fetch the pre-update widget value
-                        def _get_original_value(wf, node_id, widget_index, subgraph_id=None, is_top_level=None):
+                        def _get_widget_value(widgets_values, widget_index):
+                            """Safely get a value from widgets_values (array or dict)."""
+                            if isinstance(widgets_values, dict):
+                                return widgets_values.get(widget_index)
+                            elif isinstance(widgets_values, (list, tuple)):
+                                if isinstance(widget_index, int) and 0 <= widget_index < len(widgets_values):
+                                    return widgets_values[widget_index]
+                            return None
+
+                        def _get_original_value(wf, node_id, widget_index, subgraph_id=None, is_top_level=None, nested_key=None):
                             try:
                                 if not wf:
                                     return None
+                                value = None
                                 # Decide where to look for node
                                 if is_top_level is False or (is_top_level is None and subgraph_id):
                                     # Search subgraph definitions
@@ -138,16 +148,21 @@ class ModelLinkerExtension:
                                         if sg.get('id') == subgraph_id:
                                             for n in sg.get('nodes') or []:
                                                 if n.get('id') == node_id:
-                                                    w = n.get('widgets_values') or []
-                                                    return w[widget_index] if 0 <= widget_index < len(w) else None
-                                # Fallback/top-level
-                                for n in wf.get('nodes') or []:
-                                    if n.get('id') == node_id:
-                                        w = n.get('widgets_values') or []
-                                        return w[widget_index] if 0 <= widget_index < len(w) else None
+                                                    value = _get_widget_value(n.get('widgets_values'), widget_index)
+                                                    break
+                                            break
+                                if value is None:
+                                    # Fallback/top-level
+                                    for n in wf.get('nodes') or []:
+                                        if n.get('id') == node_id:
+                                            value = _get_widget_value(n.get('widgets_values'), widget_index)
+                                            break
+                                # Extract nested key for dict-type widgets (e.g. Power Lora Loader)
+                                if nested_key and isinstance(value, dict):
+                                    return value.get(nested_key)
+                                return value
                             except Exception:
                                 return None
-                            return None
 
                         for res in resolutions:
                             # Expect original_path from client; otherwise derive from pre-update workflow
@@ -158,7 +173,8 @@ class ModelLinkerExtension:
                                     res.get('node_id'),
                                     res.get('widget_index', 0),
                                     res.get('subgraph_id'),
-                                    res.get('is_top_level')
+                                    res.get('is_top_level'),
+                                    res.get('nested_key')
                                 )
                             category = res.get('category')
                             resolved_model = res.get('resolved_model')
@@ -248,7 +264,49 @@ class ModelLinkerExtension:
                 except Exception as e:
                     self.logger.error(f"Model Linker replace_overrides error: {e}", exc_info=True)
                     return web.json_response({'success': False, 'error': str(e)}, status=500)
-            
+
+            @routes.get("/model_linker/preview")
+            async def get_model_preview(request):
+                """Return a preview image/video for a model if one exists alongside it."""
+                import os
+                try:
+                    model_type = request.rel_url.query.get('type', '')
+                    model_file = request.rel_url.query.get('file', '')
+                    if not model_type or not model_file:
+                        return web.Response(status=400, text='type and file query params required')
+
+                    import folder_paths as fp
+                    model_path = fp.get_full_path(model_type, model_file)
+                    if not model_path or not os.path.isfile(model_path):
+                        return web.Response(status=404)
+
+                    # Security: ensure resolved path is inside a known category directory
+                    category_dirs = fp.get_folder_paths(model_type)
+                    is_safe = False
+                    for base_dir in category_dirs:
+                        try:
+                            real_model = os.path.realpath(model_path)
+                            real_base = os.path.realpath(base_dir)
+                            if os.path.commonpath([real_model, real_base]) == real_base:
+                                is_safe = True
+                                break
+                        except (ValueError, OSError):
+                            continue
+                    if not is_safe:
+                        return web.Response(status=403)
+
+                    # Look for preview files with same base name
+                    base_no_ext = os.path.splitext(model_path)[0]
+                    for ext in ('.png', '.jpg', '.jpeg', '.webp', '.mp4'):
+                        preview_path = base_no_ext + ext
+                        if os.path.isfile(preview_path):
+                            return web.FileResponse(preview_path)
+
+                    return web.Response(status=404)
+                except Exception as e:
+                    self.logger.debug(f"Model Linker preview error: {e}")
+                    return web.Response(status=404)
+
             self.routes_setup = True
             self.logger.info("Model Linker: API routes registered successfully")
             return True

--- a/__init__.py
+++ b/__init__.py
@@ -58,7 +58,14 @@ class ModelLinkerExtension:
             try:
                 from .core.linker import analyze_and_find_matches, apply_resolution
                 from .core.scanner import get_model_files
-                from .core.overrides import record_override, load_overrides, get_overrides_path
+                from .core.overrides import (
+                    record_override,
+                    load_overrides,
+                    get_overrides_path,
+                    delete_override,
+                    clear_overrides,
+                    replace_overrides,
+                )
             except ImportError as e:
                 self.logger.error(f"Model Linker: Could not import core modules: {e}")
                 return False
@@ -206,6 +213,41 @@ class ModelLinkerExtension:
                 except Exception as e:
                     self.logger.error(f"Model Linker get_overrides error: {e}", exc_info=True)
                     return web.json_response({'error': str(e)}, status=500)
+
+            @routes.post("/model_linker/overrides/delete")
+            async def delete_override_api(request):
+                try:
+                    data = await request.json()
+                    key = (data or {}).get('key')
+                    if not key:
+                        return web.json_response({'success': False, 'error': 'key is required'}, status=400)
+                    removed = delete_override(key)
+                    return web.json_response({'success': removed})
+                except Exception as e:
+                    self.logger.error(f"Model Linker delete_override error: {e}", exc_info=True)
+                    return web.json_response({'success': False, 'error': str(e)}, status=500)
+
+            @routes.post("/model_linker/overrides/clear")
+            async def clear_overrides_api(request):
+                try:
+                    clear_overrides()
+                    return web.json_response({'success': True})
+                except Exception as e:
+                    self.logger.error(f"Model Linker clear_overrides error: {e}", exc_info=True)
+                    return web.json_response({'success': False, 'error': str(e)}, status=500)
+
+            @routes.post("/model_linker/overrides/replace")
+            async def replace_overrides_api(request):
+                try:
+                    data = await request.json()
+                    overrides_doc = data.get('overrides')
+                    if overrides_doc is None:
+                        return web.json_response({'success': False, 'error': 'overrides payload required'}, status=400)
+                    ok = replace_overrides(overrides_doc)
+                    return web.json_response({'success': ok})
+                except Exception as e:
+                    self.logger.error(f"Model Linker replace_overrides error: {e}", exc_info=True)
+                    return web.json_response({'success': False, 'error': str(e)}, status=500)
             
             self.routes_setup = True
             self.logger.info("Model Linker: API routes registered successfully")

--- a/__init__.py
+++ b/__init__.py
@@ -7,6 +7,7 @@
 """
 
 import logging
+import json
 
 # Web directory for JavaScript interface
 WEB_DIRECTORY = "./web"
@@ -57,6 +58,7 @@ class ModelLinkerExtension:
             try:
                 from .core.linker import analyze_and_find_matches, apply_resolution
                 from .core.scanner import get_model_files
+                from .core.overrides import record_override, load_overrides, get_overrides_path
             except ImportError as e:
                 self.logger.error(f"Model Linker: Could not import core modules: {e}")
                 return False
@@ -105,8 +107,60 @@ class ModelLinkerExtension:
                             status=400
                         )
                     
+                    # Make a deep copy of workflow to recover original widget values if needed
+                    try:
+                        workflow_before = json.loads(json.dumps(workflow_json))
+                    except Exception:
+                        workflow_before = None
+
                     # Apply resolutions
                     updated_workflow = apply_resolution(workflow_json, resolutions)
+
+                    # Persist user choices as overrides (so next time we know the correct match)
+                    try:
+                        # helper to fetch the pre-update widget value
+                        def _get_original_value(wf, node_id, widget_index, subgraph_id=None, is_top_level=None):
+                            try:
+                                if not wf:
+                                    return None
+                                # Decide where to look for node
+                                if is_top_level is False or (is_top_level is None and subgraph_id):
+                                    # Search subgraph definitions
+                                    defs = (wf.get('definitions') or {}).get('subgraphs') or []
+                                    for sg in defs:
+                                        if sg.get('id') == subgraph_id:
+                                            for n in sg.get('nodes') or []:
+                                                if n.get('id') == node_id:
+                                                    w = n.get('widgets_values') or []
+                                                    return w[widget_index] if 0 <= widget_index < len(w) else None
+                                # Fallback/top-level
+                                for n in wf.get('nodes') or []:
+                                    if n.get('id') == node_id:
+                                        w = n.get('widgets_values') or []
+                                        return w[widget_index] if 0 <= widget_index < len(w) else None
+                            except Exception:
+                                return None
+                            return None
+
+                        for res in resolutions:
+                            # Expect original_path from client; otherwise derive from pre-update workflow
+                            original_path = res.get('original_path')
+                            if not original_path:
+                                original_path = _get_original_value(
+                                    workflow_before,
+                                    res.get('node_id'),
+                                    res.get('widget_index', 0),
+                                    res.get('subgraph_id'),
+                                    res.get('is_top_level')
+                                )
+                            category = res.get('category')
+                            resolved_model = res.get('resolved_model')
+                            resolved_path = res.get('resolved_path')
+                            if original_path and (resolved_model or resolved_path):
+                                record_override(original_path, category, resolved_model, resolved_path)
+                    except Exception as e:
+                        # Do not fail the request if persisting overrides fails
+                        self.logger.warning(f"Model Linker: Failed to record overrides: {e}")
                     
                     return web.json_response({
                         'workflow': updated_workflow,
@@ -131,6 +185,27 @@ class ModelLinkerExtension:
                         {'error': str(e)},
                         status=500
                     )
+
+            @routes.get("/model_linker/overrides")
+            async def get_overrides(request):
+                """Return current overrides and the file path used for persistence."""
+                try:
+                    doc = load_overrides()
+                    path = get_overrides_path()
+                    exists = False
+                    try:
+                        import os
+                        exists = os.path.exists(path)
+                    except Exception:
+                        pass
+                    return web.json_response({
+                        'path': path,
+                        'exists': exists,
+                        'overrides': doc,
+                    })
+                except Exception as e:
+                    self.logger.error(f"Model Linker get_overrides error: {e}", exc_info=True)
+                    return web.json_response({'error': str(e)}, status=500)
             
             self.routes_setup = True
             self.logger.info("Model Linker: API routes registered successfully")

--- a/core/linker.py
+++ b/core/linker.py
@@ -188,7 +188,8 @@ def apply_resolution(
             'category': resolution.get('category'),
             'resolved_model': resolution.get('resolved_model'),
             'subgraph_id': resolution.get('subgraph_id'),  # Include subgraph_id for subgraph nodes
-            'is_top_level': resolution.get('is_top_level')  # True for top-level nodes, False for nodes in subgraph definitions
+            'is_top_level': resolution.get('is_top_level'),  # True for top-level nodes, False for nodes in subgraph definitions
+            'nested_key': resolution.get('nested_key'),  # For dict-type widgets (e.g. Power Lora Loader)
         }
         
         # If resolved_model provided, extract path if needed

--- a/core/linker.py
+++ b/core/linker.py
@@ -12,6 +12,7 @@ from .scanner import get_model_files
 from .workflow_analyzer import analyze_workflow_models, identify_missing_models
 from .matcher import find_matches
 from .workflow_updater import update_workflow_nodes
+from .overrides import find_override_model
 
 
 def analyze_and_find_matches(
@@ -85,13 +86,38 @@ def analyze_and_find_matches(
             # Also include other categories as fallback
             candidates.extend([m for m in available_models if m.get('category') != category])
         
-        # Find matches
+        # First: compute fuzzy matches as usual
         matches = find_matches(
             original_path,
             candidates,
             threshold=similarity_threshold,
             max_results=max_matches_per_model
         )
+
+        # Then: check if user has a saved override; inject it as a 99% match (not 100%)
+        override_model = find_override_model(original_path, category, available_models)
+        if override_model is not None:
+            override_path = os.path.normpath(override_model.get('path', '') or '')
+            # Check if already present in matches
+            found = None
+            for m in matches:
+                p = os.path.normpath(m.get('model', {}).get('path', '') or '')
+                if p and p == override_path:
+                    found = m
+                    break
+            if found:
+                # Boost to 100% and mark as override
+                found['similarity'] = 1.0
+                found['confidence'] = 100.0
+                found['is_override'] = True
+            else:
+                matches.append({
+                    'model': override_model,
+                    'filename': override_model.get('filename'),
+                    'similarity': 1.0,
+                    'confidence': 100.0,
+                    'is_override': True,
+                })
         
         # Deduplicate matches by absolute path - same physical file should only appear once
         # This handles cases where the same file exists in multiple base directories

--- a/core/overrides.py
+++ b/core/overrides.py
@@ -66,6 +66,54 @@ def _save_overrides(doc: Dict[str, Any]) -> None:
         logging.warning(f"Model Linker: Failed to save overrides: {e}")
 
 
+def delete_override(key: str) -> bool:
+    """Delete a single override by its key. Returns True if removed."""
+    if not key:
+        return False
+    doc = load_overrides()
+    before = len(doc.get("mappings", []))
+    doc["mappings"] = [m for m in doc.get("mappings", []) if m.get("key") != key]
+    after = len(doc.get("mappings", []))
+    if after != before:
+        _save_overrides(doc)
+        return True
+    return False
+
+
+def clear_overrides() -> None:
+    """Clear all overrides (resets the document)."""
+    _save_overrides(_default_doc())
+
+
+def replace_overrides(new_doc: Dict[str, Any]) -> bool:
+    """Replace overrides with a new document if valid. Returns True on success."""
+    try:
+        if not isinstance(new_doc, dict):
+            return False
+        mappings = new_doc.get("mappings")
+        if mappings is None:
+            # Allow passing list directly
+            if isinstance(new_doc, list):
+                mappings = new_doc
+                new_doc = {"version": 1, "mappings": mappings}
+            else:
+                return False
+        if not isinstance(mappings, list):
+            return False
+        # Basic sanitize: only keep dict entries with key and path
+        clean: List[Dict[str, Any]] = []
+        for m in mappings:
+            if isinstance(m, dict) and m.get("key") and m.get("path"):
+                clean.append(m)
+        new_doc["version"] = int(new_doc.get("version", 1))
+        new_doc["mappings"] = clean
+        _save_overrides(new_doc)
+        return True
+    except Exception:
+        logging.exception("Model Linker: Failed to replace overrides")
+        return False
+
+
 def _make_keys(original_path: str, category: Optional[str]) -> List[str]:
     """
     Produce candidate keys for lookup.

--- a/core/overrides.py
+++ b/core/overrides.py
@@ -1,0 +1,193 @@
+"""
+User Overrides Module
+
+Stores and retrieves user-selected replacements so future analyses
+can auto-suggest or auto-resolve to the saved match.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from .matcher import normalize_filename
+
+
+def _data_dir() -> str:
+    """Return the directory path for storing persistence data."""
+    # Place under the extension directory in a `data` subfolder
+    base = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    data = os.path.join(base, "data")
+    os.makedirs(data, exist_ok=True)
+    return data
+
+
+def _overrides_path() -> str:
+    return os.path.join(_data_dir(), "overrides.json")
+
+
+def get_overrides_path() -> str:
+    """Public helper to report the absolute path used for overrides.json."""
+    return _overrides_path()
+
+
+def _default_doc() -> Dict[str, Any]:
+    return {"version": 1, "mappings": []}
+
+
+def load_overrides() -> Dict[str, Any]:
+    """Load overrides JSON; returns a dictionary with key 'mappings' (list)."""
+    path = _overrides_path()
+    try:
+        if not os.path.exists(path):
+            return _default_doc()
+        with open(path, "r", encoding="utf-8") as f:
+            doc = json.load(f)
+            # Basic shape validation
+            if not isinstance(doc, dict) or "mappings" not in doc:
+                return _default_doc()
+            if not isinstance(doc["mappings"], list):
+                doc["mappings"] = []
+            return doc
+    except Exception as e:
+        logging.warning(f"Model Linker: Failed to load overrides: {e}")
+        return _default_doc()
+
+
+def _save_overrides(doc: Dict[str, Any]) -> None:
+    path = _overrides_path()
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(doc, f, indent=2)
+        logging.info(f"Model Linker: Saved overrides to {path}")
+    except Exception as e:
+        logging.warning(f"Model Linker: Failed to save overrides: {e}")
+
+
+def _make_keys(original_path: str, category: Optional[str]) -> List[str]:
+    """
+    Produce candidate keys for lookup.
+    Primary: category + normalized filename; Fallback: any + normalized filename
+    """
+    filename = os.path.basename(original_path or "").strip()
+    norm = normalize_filename(filename) if filename else ""
+    cat = (category or "").strip().lower() or "any"
+    if cat in ("unknown", "none", "undefined"):
+        cat = "any"
+    keys = [f"{cat}:{norm}"]
+    if cat != "any":
+        keys.append(f"any:{norm}")
+    return keys
+
+
+def find_override_path(original_path: str, category: Optional[str]) -> Optional[str]:
+    """Return stored absolute path for a given (original_path, category), if any."""
+    doc = load_overrides()
+    keys = _make_keys(original_path, category)
+    # Build quick lookup
+    lookup: Dict[str, Dict[str, Any]] = {}
+    for m in doc.get("mappings", []):
+        k = m.get("key")
+        if isinstance(k, str):
+            lookup[k] = m
+    for k in keys:
+        m = lookup.get(k)
+        if m and m.get("path"):
+            return m.get("path")
+
+    # Fallback: match by normalized filename regardless of saved category
+    try:
+        filename = os.path.basename(original_path or "").strip()
+        norm = normalize_filename(filename) if filename else ""
+        if norm:
+            for m in doc.get("mappings", []):
+                key = m.get("key") or ""
+                if isinstance(key, str) and ":" in key:
+                    _, saved_norm = key.split(":", 1)
+                    if saved_norm == norm and m.get("path"):
+                        return m.get("path")
+    except Exception:
+        pass
+    return None
+
+
+def find_override_model(original_path: str, category: Optional[str], available_models: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """
+    Return the model dict from available_models for a saved override, if present.
+    """
+    saved_path = find_override_path(original_path, category)
+    if not saved_path:
+        return None
+    try:
+        saved_norm = os.path.normpath(saved_path)
+    except Exception:
+        saved_norm = saved_path
+    for m in available_models:
+        p = m.get("path")
+        try:
+            if p and os.path.normpath(p) == saved_norm:
+                return m
+        except Exception:
+            if p == saved_path:
+                return m
+    # If not found (file moved/removed), do not return stale override
+    return None
+
+
+def record_override(original_path: str, category: Optional[str], resolved: Dict[str, Any] | None = None, resolved_path: Optional[str] = None) -> bool:
+    """
+    Record a user-selected override.
+
+    Args:
+        original_path: original missing value from workflow
+        category: model category if known
+        resolved: model dict from scanner (preferred)
+        resolved_path: absolute path if model dict not provided
+
+    Returns:
+        True if the override file was updated, else False.
+    """
+    path = None
+    if isinstance(resolved, dict):
+        path = resolved.get("path") or resolved_path
+    else:
+        path = resolved_path
+    if not original_path or not path:
+        return False
+
+    filename = os.path.basename(original_path)
+    key = _make_keys(original_path, category)[0]  # primary key (category-aware)
+
+    # Normalize category consistently with _make_keys
+    cat = (category or "").strip().lower() or "any"
+    if cat in ("unknown", "none", "undefined"):
+        cat = "any"
+
+    entry: Dict[str, Any] = {
+        "key": key,
+        "original_filename": filename,
+        "category": cat,
+        "path": path,
+    }
+    # Optional metadata for convenience
+    if isinstance(resolved, dict):
+        for k in ("filename", "relative_path", "base_directory"):
+            if k in resolved:
+                entry[k] = resolved[k]
+
+    doc = load_overrides()
+    mappings = doc.get("mappings", [])
+    # replace or append
+    replaced = False
+    for i, m in enumerate(mappings):
+        if m.get("key") == key:
+            mappings[i] = entry
+            replaced = True
+            break
+    if not replaced:
+        mappings.append(entry)
+    doc["mappings"] = mappings
+    _save_overrides(doc)
+    return True

--- a/core/scanner.py
+++ b/core/scanner.py
@@ -17,7 +17,7 @@ except ImportError:
 
 # Model file extensions to look for
 # This matches folder_paths.supported_pt_extensions
-MODEL_EXTENSIONS = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft', '.onnx'}
+MODEL_EXTENSIONS = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft', '.onnx', '.gguf'}
 
 
 def get_model_directories() -> Dict[str, Tuple[List[str], set]]:

--- a/core/workflow_analyzer.py
+++ b/core/workflow_analyzer.py
@@ -19,6 +19,14 @@ except ImportError:
 # Common model file extensions
 MODEL_EXTENSIONS = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft', '.onnx'}
 
+# Node types that should never be scanned for model references.
+# These are note/utility nodes whose widget values may contain model filenames
+# as text content (e.g. markdown links) but are NOT actual model references.
+SKIP_NODE_TYPES = {
+    'MarkdownNote', 'Note', 'NoteNode', 'TextNote',
+    'Reroute', 'PrimitiveNode',
+}
+
 # Mapping of common node types to their expected model category
 # This is used as hints but we don't rely solely on this
 # UNETLoader uses 'diffusion_models' category (folder_paths maps 'unet' to 'diffusion_models')
@@ -32,8 +40,13 @@ NODE_TYPE_TO_CATEGORY_HINTS = {
     'UNETLoader': 'diffusion_models',  # UNETLoader uses diffusion_models category
     'ControlNetLoader': 'controlnet',
     'ControlNetLoaderAdvanced': 'controlnet',
+    'CLIPLoader': 'text_encoders',
+    'DualCLIPLoader': 'text_encoders',
+    'TripleCLIPLoader': 'text_encoders',
     'CLIPVisionLoader': 'clip_vision',
     'UpscaleModelLoader': 'upscale_models',
+    'LatentUpscaleModelLoader': 'latent_upscale_models',
+    'StyleModelLoader': 'style_models',
     'HypernetworkLoader': 'hypernetworks',
     'EmbeddingLoader': 'embeddings',
 }
@@ -107,19 +120,24 @@ def try_resolve_model_path(value: str, categories: List[str] = None) -> Optional
 def get_node_model_info(node: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
     Extract model references from a single node.
-    
+
     This scans all widgets_values entries and tries to identify which ones
     are model file references by attempting to resolve them.
-    
+
+    Handles both array and dict formats for widgets_values (newer ComfyUI
+    frontends may serialize widgets_values as an object with named keys).
+
+    Uses properties.models (when available) for accurate category detection.
+
     Args:
         node: Node dictionary from workflow JSON
-        
+
     Returns:
         List of model reference dictionaries:
         {
             'node_id': node id,
             'node_type': node type,
-            'widget_index': index in widgets_values,
+            'widget_index': index in widgets_values (int for array, str for dict),
             'original_path': original path from workflow,
             'category': model category (if found),
             'exists': True if model exists
@@ -128,33 +146,57 @@ def get_node_model_info(node: Dict[str, Any]) -> List[Dict[str, Any]]:
     model_refs = []
     node_id = node.get('id')
     node_type = node.get('type', '')
-    widgets_values = node.get('widgets_values', [])
-    
+
+    # Skip note/markdown/utility node types that don't contain model references
+    if node_type in SKIP_NODE_TYPES:
+        return model_refs
+
+    widgets_values = node.get('widgets_values')
     if not widgets_values:
         return model_refs
-    
+
     # Get category hints for this node type
     category_hint = NODE_TYPE_TO_CATEGORY_HINTS.get(node_type)
-    categories_to_try = [category_hint] if category_hint else None
-    
-    # For each widget value, check if it looks like a model file
-    for idx, value in enumerate(widgets_values):
+
+    # Build per-model category map from properties.models (newer ComfyUI feature)
+    # This provides reliable category info for each model the node expects
+    properties_models = (node.get('properties') or {}).get('models') or []
+    model_category_map: Dict[str, str] = {}
+    for pm in properties_models:
+        name = pm.get('name', '')
+        directory = pm.get('directory', '')
+        if name and directory:
+            model_category_map[name] = directory
+
+    # Handle both array and dict format for widgets_values
+    if isinstance(widgets_values, dict):
+        items = list(widgets_values.items())  # [(key, value), ...]
+    elif isinstance(widgets_values, (list, tuple)):
+        items = list(enumerate(widgets_values))  # [(index, value), ...]
+    else:
+        return model_refs
+
+    for idx, value in items:
         if not is_model_filename(value):
             continue
-        
+
+        # Determine best category: properties.models > node type hint > all categories
+        value_category = model_category_map.get(value) or category_hint
+        categories_to_try = [value_category] if value_category else None
+
         # Try to resolve the model path
         resolved = try_resolve_model_path(value, categories_to_try)
-        
+
         if resolved:
             category, full_path = resolved
             exists = os.path.exists(full_path)
         else:
             # If we can't resolve it, check if it at least looks like a model filename
             # This might be a missing model or a custom node's model
-            category = category_hint or 'unknown'
+            category = value_category or 'unknown'
             full_path = None
             exists = False
-        
+
         model_refs.append({
             'node_id': node_id,
             'node_type': node_type,
@@ -164,7 +206,7 @@ def get_node_model_info(node: Dict[str, Any]) -> List[Dict[str, Any]]:
             'full_path': full_path,
             'exists': exists
         })
-    
+
     return model_refs
 
 

--- a/core/workflow_analyzer.py
+++ b/core/workflow_analyzer.py
@@ -17,7 +17,7 @@ except ImportError:
 
 
 # Common model file extensions
-MODEL_EXTENSIONS = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft', '.onnx'}
+MODEL_EXTENSIONS = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft', '.onnx', '.gguf'}
 
 # Node types that should never be scanned for model references.
 # These are note/utility nodes whose widget values may contain model filenames
@@ -49,6 +49,23 @@ NODE_TYPE_TO_CATEGORY_HINTS = {
     'StyleModelLoader': 'style_models',
     'HypernetworkLoader': 'hypernetworks',
     'EmbeddingLoader': 'embeddings',
+    'Power Lora Loader (rgthree)': 'loras',
+    # LTX-Video nodes
+    'LTXVAudioVAELoader': 'checkpoints',
+    'LowVRAMAudioVAELoader': 'checkpoints',
+    'LTXVGemmaCLIPModelLoader': 'text_encoders',
+}
+
+# Keys within dict-type widget values that contain model file references.
+# Some nodes (e.g. rgthree Power Lora Loader) store model info as objects like
+# {"on": true, "lora": "name.safetensors", "strength": 1.0} inside widgets_values.
+# Maps nested key name -> category hint.
+NESTED_MODEL_KEYS = {
+    'lora': 'loras',
+    'ckpt_name': 'checkpoints',
+    'checkpoint': 'checkpoints',
+    'vae_name': 'vae',
+    'control_net_name': 'controlnet',
 }
 
 
@@ -158,15 +175,17 @@ def get_node_model_info(node: Dict[str, Any]) -> List[Dict[str, Any]]:
     # Get category hints for this node type
     category_hint = NODE_TYPE_TO_CATEGORY_HINTS.get(node_type)
 
-    # Build per-model category map from properties.models (newer ComfyUI feature)
-    # This provides reliable category info for each model the node expects
+    # Build per-input category map from properties.models (newer ComfyUI feature).
+    # This maps widget INPUT NAMES (e.g. "ckpt_name") to their folder_paths category
+    # (e.g. "checkpoints"), allowing detection of model inputs even when the stored
+    # value lacks a standard model file extension.
     properties_models = (node.get('properties') or {}).get('models') or []
-    model_category_map: Dict[str, str] = {}
+    model_input_categories: Dict[str, str] = {}
     for pm in properties_models:
         name = pm.get('name', '')
         directory = pm.get('directory', '')
         if name and directory:
-            model_category_map[name] = directory
+            model_input_categories[name] = directory
 
     # Handle both array and dict format for widgets_values
     if isinstance(widgets_values, dict):
@@ -177,35 +196,75 @@ def get_node_model_info(node: Dict[str, Any]) -> List[Dict[str, Any]]:
         return model_refs
 
     for idx, value in items:
-        if not is_model_filename(value):
-            continue
+        # For dict-format widgets_values, idx is the input name (str key).
+        # Check if properties.models identifies this input as a model widget.
+        input_category = model_input_categories.get(idx) if isinstance(idx, str) else None
 
-        # Determine best category: properties.models > node type hint > all categories
-        value_category = model_category_map.get(value) or category_hint
-        categories_to_try = [value_category] if value_category else None
+        # Case 1: Direct string value — detected either by file extension
+        # or by properties.models metadata identifying this as a model input
+        if isinstance(value, str) and value.strip():
+            has_model_ext = is_model_filename(value)
+            is_known_model_input = input_category is not None
 
-        # Try to resolve the model path
-        resolved = try_resolve_model_path(value, categories_to_try)
+            if has_model_ext or is_known_model_input:
+                # Determine best category: properties.models > node type hint > all
+                value_category = input_category or category_hint
+                categories_to_try = [value_category] if value_category else None
 
-        if resolved:
-            category, full_path = resolved
-            exists = os.path.exists(full_path)
-        else:
-            # If we can't resolve it, check if it at least looks like a model filename
-            # This might be a missing model or a custom node's model
-            category = value_category or 'unknown'
-            full_path = None
-            exists = False
+                # Try to resolve the model path
+                resolved = try_resolve_model_path(value, categories_to_try)
 
-        model_refs.append({
-            'node_id': node_id,
-            'node_type': node_type,
-            'widget_index': idx,
-            'original_path': value,
-            'category': category,
-            'full_path': full_path,
-            'exists': exists
-        })
+                if resolved:
+                    category, full_path = resolved
+                    exists = os.path.exists(full_path)
+                else:
+                    category = value_category or 'unknown'
+                    full_path = None
+                    exists = False
+
+                model_refs.append({
+                    'node_id': node_id,
+                    'node_type': node_type,
+                    'widget_index': idx,
+                    'original_path': value,
+                    'category': category,
+                    'full_path': full_path,
+                    'exists': exists,
+                    'nested_key': None
+                })
+                continue
+
+        # Case 2: Dict value containing a model reference key
+        # e.g. {"on": true, "lora": "name.safetensors", "strength": 1.0}
+        if isinstance(value, dict):
+            for nested_key, nested_category_hint in NESTED_MODEL_KEYS.items():
+                nested_value = value.get(nested_key)
+                if not nested_value or not is_model_filename(nested_value):
+                    continue
+
+                value_category = nested_category_hint or category_hint
+                categories_to_try = [value_category] if value_category else None
+
+                resolved = try_resolve_model_path(nested_value, categories_to_try)
+
+                if resolved:
+                    category, full_path = resolved
+                    exists = os.path.exists(full_path)
+                else:
+                    category = value_category or 'unknown'
+                    full_path = None
+                    exists = False
+
+                model_refs.append({
+                    'node_id': node_id,
+                    'node_type': node_type,
+                    'widget_index': idx,
+                    'original_path': nested_value,
+                    'category': category,
+                    'full_path': full_path,
+                    'exists': exists,
+                    'nested_key': nested_key
+                })
 
     return model_refs
 

--- a/core/workflow_updater.py
+++ b/core/workflow_updater.py
@@ -194,9 +194,18 @@ def update_model_path(
         return False
     
     widgets_values = node.get('widgets_values', [])
-    
-    if widget_index >= len(widgets_values):
-        logging.warning(f"Widget index {widget_index} out of range for node {node_id}")
+
+    # Handle both array and dict format for widgets_values
+    if isinstance(widgets_values, dict):
+        if widget_index not in widgets_values:
+            logging.warning(f"Widget key {widget_index!r} not found in node {node_id}")
+            return False
+    elif isinstance(widgets_values, (list, tuple)):
+        if not isinstance(widget_index, int) or widget_index >= len(widgets_values):
+            logging.warning(f"Widget index {widget_index} out of range for node {node_id}")
+            return False
+    else:
+        logging.warning(f"Unexpected widgets_values type {type(widgets_values).__name__} for node {node_id}")
         return False
     
     # Get category from resolved_model if not provided

--- a/core/workflow_updater.py
+++ b/core/workflow_updater.py
@@ -116,7 +116,8 @@ def update_model_path(
     base_directory: str = None,
     resolved_model: Dict[str, Any] = None,
     subgraph_id: str = None,
-    is_top_level: bool = None
+    is_top_level: bool = None,
+    nested_key: str = None
 ) -> bool:
     """
     Update a single model path in a workflow node, supporting both top-level and subgraph nodes.
@@ -225,10 +226,13 @@ def update_model_path(
     else:
         relative_path = resolved_path
     
-    # Update the widget value
-    widgets_values[widget_index] = relative_path
-    
-    logging.debug(f"Updated node {node_id}, widget {widget_index} to: {relative_path}")
+    # Update the widget value (handle nested dict values like Power Lora Loader)
+    if nested_key and isinstance(widgets_values[widget_index], dict):
+        widgets_values[widget_index][nested_key] = relative_path
+    else:
+        widgets_values[widget_index] = relative_path
+
+    logging.debug(f"Updated node {node_id}, widget {widget_index}{('[' + nested_key + ']') if nested_key else ''} to: {relative_path}")
     return True
 
 
@@ -276,7 +280,8 @@ def update_workflow_nodes(
         resolved_model = mapping.get('resolved_model')
         subgraph_id = mapping.get('subgraph_id')
         is_top_level = mapping.get('is_top_level')  # True for top-level nodes, False for nodes in subgraph definitions
-        
+        nested_key = mapping.get('nested_key')  # For dict-type widgets (e.g. Power Lora Loader)
+
         success = update_model_path(
             workflow,
             node_id,
@@ -286,7 +291,8 @@ def update_workflow_nodes(
             base_directory,
             resolved_model,
             subgraph_id,
-            is_top_level
+            is_top_level,
+            nested_key
         )
         
         if success:

--- a/web/linker.js
+++ b/web/linker.js
@@ -1436,7 +1436,7 @@ class LinkerManagerDialog extends ComfyDialog {
 
             if (resolveData.success) {
                 // Update workflow in ComfyUI
-                await this.updateWorkflowInComfyUI(resolveData.workflow);
+                await this.updateWorkflowInComfyUI(resolveData.workflow, resolutions);
 
                 // Show success notification
                 this.showNotification(
@@ -1484,7 +1484,7 @@ class LinkerManagerDialog extends ComfyDialog {
 
             const data = await response.json();
             if (data.success) {
-                await this.updateWorkflowInComfyUI(data.workflow);
+                await this.updateWorkflowInComfyUI(data.workflow, list);
                 this.showNotification(`✓ Linked ${list.length} selection${list.length > 1 ? 's' : ''}`, 'success');
                 // Clear queue and refresh analysis
                 this.pendingResolutions = [];
@@ -1768,42 +1768,91 @@ class LinkerManagerDialog extends ComfyDialog {
      * Update workflow in ComfyUI's UI/memory
      * Updates the current workflow in place instead of creating a new tab
      */
-    async updateWorkflowInComfyUI(workflow) {
+    async updateWorkflowInComfyUI(workflow, resolutions) {
         if (!app || !app.graph) {
             console.warn('Model Linker: Could not update workflow - app or app.graph not available');
             return;
         }
 
         try {
-            // Method 1: Try to directly update the current graph using configure
-            // This is the most direct way to update in place
-            if (app.graph && typeof app.graph.configure === 'function') {
-                app.graph.configure(workflow);
+            // Strategy: Directly update only the changed widget values on live graph nodes.
+            // Previous approach used graph.configure() which clears the entire graph and
+            // rebuilds from scratch — causing all nodes to disappear on newer ComfyUI versions.
+            if (resolutions && resolutions.length > 0) {
+                let updatedCount = 0;
+
+                for (const res of resolutions) {
+                    const nodeId = res.node_id;
+                    const widgetIndex = res.widget_index;
+
+                    // Get the new value from the updated workflow returned by backend
+                    let newValue = undefined;
+                    const workflowNodes = workflow?.nodes || [];
+                    for (const wn of workflowNodes) {
+                        if (wn.id === nodeId) {
+                            const wv = wn.widgets_values;
+                            if (Array.isArray(wv) && widgetIndex >= 0 && widgetIndex < wv.length) {
+                                newValue = wv[widgetIndex];
+                            } else if (wv && typeof wv === 'object' && widgetIndex in wv) {
+                                newValue = wv[widgetIndex];
+                            }
+                            break;
+                        }
+                    }
+
+                    // Also check subgraph definitions if not found in top-level nodes
+                    if (newValue === undefined && res.subgraph_id && res.is_top_level === false) {
+                        const defs = (workflow?.definitions?.subgraphs) || [];
+                        for (const sg of defs) {
+                            if (sg.id === res.subgraph_id) {
+                                for (const wn of (sg.nodes || [])) {
+                                    if (wn.id === nodeId) {
+                                        const wv = wn.widgets_values;
+                                        if (Array.isArray(wv) && widgetIndex >= 0 && widgetIndex < wv.length) {
+                                            newValue = wv[widgetIndex];
+                                        } else if (wv && typeof wv === 'object' && widgetIndex in wv) {
+                                            newValue = wv[widgetIndex];
+                                        }
+                                        break;
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                    }
+
+                    if (newValue === undefined) continue;
+
+                    // Find the live node in the graph and update its widget value directly
+                    const node = app.graph.getNodeById(nodeId);
+                    if (!node) {
+                        console.debug(`Model Linker: Node ${nodeId} not found in live graph (may be inside subgraph definition)`);
+                        continue;
+                    }
+
+                    if (node.widgets && node.widgets[widgetIndex]) {
+                        node.widgets[widgetIndex].value = newValue;
+                        // Trigger widget callback if available (updates combo dropdowns, etc.)
+                        if (typeof node.widgets[widgetIndex].callback === 'function') {
+                            try { node.widgets[widgetIndex].callback(newValue); } catch (_) { /* ignore */ }
+                        }
+                        updatedCount++;
+                    }
+                }
+
+                // Refresh the canvas to reflect changes
+                if (updatedCount > 0) {
+                    app.graph.setDirtyCanvas(true, true);
+                }
                 return;
             }
 
-            // Method 2: Try deserialize to update the graph in place
-            if (app.graph && typeof app.graph.deserialize === 'function') {
-                app.graph.deserialize(workflow);
-                return;
-            }
-
-            // Method 3: Use loadGraphData with explicit parameters to update current tab
-            // The key is to NOT create a new workflow - pass null or undefined for the workflow parameter
-            // clean=false means don't clear the graph first
-            // restore_view=false means don't restore the viewport
-            // workflow=null means update current workflow instead of creating new one
+            // Fallback: if no resolutions provided, use loadGraphData
             if (app.loadGraphData) {
-                // Try with null as 4th parameter first
                 await app.loadGraphData(workflow, false, false, null);
-                return;
             }
-
-            console.warn('Model Linker: No method available to update workflow');
         } catch (error) {
             console.error('Model Linker: Error updating workflow in ComfyUI:', error);
-            // Don't throw - allow the workflow update to continue even if UI update fails
-            // The backend has already updated the workflow data
         }
     }
 }

--- a/web/linker.js
+++ b/web/linker.js
@@ -745,6 +745,17 @@ class LinkerManagerDialog extends ComfyDialog {
         }
     }
 
+    /** Extract the containing folder from a model dict (display-only, never sent to nodes). */
+    _getModelFolder(model) {
+        if (!model) return '';
+        // Use absolute path and strip the filename to get the directory
+        const absPath = model.path || '';
+        if (!absPath) return model.base_directory || '';
+        // Handle both / and \ separators
+        const lastSep = Math.max(absPath.lastIndexOf('/'), absPath.lastIndexOf('\\'));
+        return lastSep > 0 ? absPath.substring(0, lastSep) : '';
+    }
+
     // ────────────────────────────────────────────────────────────────
 
     /**
@@ -1240,10 +1251,15 @@ class LinkerManagerDialog extends ComfyDialog {
                     html += ` <span style="color:#0aa96e; font-weight:600;">(saved)</span>`;
                 }
                 // Always provide a Resolve button so the user can pick explicitly
-                html += ` <button id="${buttonId}" 
+                html += ` <button id="${buttonId}"
                         class="model-linker-resolve-btn" style="margin-left: 8px; padding: 4px 8px;">
                         Select
                     </button>`;
+                // Show folder location (UI-only, not sent to nodes)
+                const folderPath = this._getModelFolder(match.model);
+                if (folderPath) {
+                    html += `<div style="font-size:11px; color:#888; opacity:0.8; margin-top:1px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${folderPath}">📁 ${folderPath}</div>`;
+                }
                 html += `</li>`;
             }
 
@@ -1695,9 +1711,14 @@ class LinkerManagerDialog extends ComfyDialog {
                     labelHtml = out;
                 }
                 const activeStyle = (i === activeIdx) ? 'background: rgba(0,122,204,0.25);' : '';
-                html += `<div data-idx="${i}" style="${activeStyle} padding:6px; display:flex; align-items:center; gap:6px; cursor:pointer;">
-                    <code style="flex:1;">${labelHtml}</code>
-                    ${isSaved ? '<span style="color:#0aa96e; font-weight:600;">(saved)</span>' : ''}
+                const folderPath = this._getModelFolder(m);
+                const folderHtml = folderPath ? `<div style="font-size:10px; color:#888; opacity:0.8; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${esc(folderPath)}">📁 ${esc(folderPath)}</div>` : '';
+                html += `<div data-idx="${i}" style="${activeStyle} padding:6px; cursor:pointer;">
+                    <div style="display:flex; align-items:center; gap:6px;">
+                        <code style="flex:1;">${labelHtml}</code>
+                        ${isSaved ? '<span style="color:#0aa96e; font-weight:600;">(saved)</span>' : ''}
+                    </div>
+                    ${folderHtml}
                 </div>`;
             }
             listEl.innerHTML = html;

--- a/web/linker.js
+++ b/web/linker.js
@@ -1864,10 +1864,12 @@ class ManageOverridesDialog extends ComfyDialog {
         let html = '';
         for (const m of filtered) {
             const delId = `ovr-del-${m.key}`.replace(/[^a-zA-Z0-9_-]/g, '_');
-            html += `<div style="border:1px solid var(--border-color); border-radius:4px; padding:6px 8px; display:flex; gap:8px; align-items:center;">
-                <div style="flex: 2 1 40%; font-weight:600; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${m.original_filename || ''}">${m.original_filename || ''}</code> <span style="opacity:.8;">[${m.category || 'any'}]</span></div>
-                <div style="flex: 3 1 55%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${m.path || ''}">${m.path || ''}</code></div>
-                <div style="flex: 0 0 auto; width: 72px; text-align: right;"><button id="${delId}" class="model-linker-resolve-btn" style="padding:4px 8px;">Delete</button></div>
+            html += `<div style="border:1px solid var(--border-color); border-radius:4px; padding:8px; display:flex; flex-direction:column; gap:6px;">
+                <div style="display:flex; align-items:center; justify-content:space-between; gap:8px;">
+                    <div style="flex:1 1 auto; font-weight:600; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${m.original_filename || ''}">${m.original_filename || ''}</code> <span style="opacity:.8;">[${m.category || 'any'}]</span></div>
+                    <div style="flex:0 0 auto;"><button id="${delId}" class="model-linker-resolve-btn" style="padding:4px 8px;">Delete</button></div>
+                </div>
+                <div style="overflow-wrap:anywhere;"><code title="${m.path || ''}">${m.path || ''}</code></div>
             </div>`;
         }
         this.listEl.innerHTML = html;

--- a/web/linker.js
+++ b/web/linker.js
@@ -222,7 +222,8 @@ class LinkerManagerDialog extends ComfyDialog {
                 gap: "12px",
                 padding: "16px",
                 flex: "1",
-                minHeight: "0"
+                minHeight: "0",
+                alignItems: "stretch"
             }
         });
 
@@ -239,8 +240,8 @@ class LinkerManagerDialog extends ComfyDialog {
             id: "model-linker-queue",
             style: {
                 width: "320px",
-                minWidth: "280px",
-                maxWidth: "360px",
+                minWidth: "240px",
+                maxWidth: "70%",
                 borderLeft: "1px solid var(--border-color)",
                 paddingLeft: "12px",
                 display: "flex",
@@ -250,8 +251,41 @@ class LinkerManagerDialog extends ComfyDialog {
             this.createQueuePanel()
         ]);
 
+        // Splitter between content and queue
+        this.splitterElement = $el("div", {
+            id: "model-linker-splitter",
+            title: "Drag to resize panels",
+            style: {
+                cursor: "col-resize",
+                width: "6px",
+                minWidth: "6px",
+                background: "var(--border-color)",
+                opacity: "0.4",
+                borderRadius: "3px"
+            },
+            ondragstart: (e) => e.preventDefault()
+        });
+
         body.appendChild(this.contentElement);
+        body.appendChild(this.splitterElement);
         body.appendChild(this.queueElement);
+
+        // Restore saved queue width and wire splitter
+        try {
+            const savedSplit = localStorage.getItem('model_linker_split_w');
+            if (savedSplit) {
+                const w = parseInt(savedSplit, 10);
+                if (!isNaN(w) && w > 0) {
+                    this.queueElement.style.width = `${w}px`;
+                }
+            }
+        } catch (e) {}
+
+        try {
+            const onSplitMouseDown = (e) => this.startSplitDrag(e);
+            this.splitterElement.addEventListener('mousedown', onSplitMouseDown);
+            this._splitterMouseDown = onSplitMouseDown;
+        } catch (e) {}
         return body;
     }
 
@@ -289,7 +323,7 @@ class LinkerManagerDialog extends ComfyDialog {
             }
         });
 
-        const panel = $el("div", { style: { display: "flex", flexDirection: "column", minHeight: "0" } }, [this.queueHeader, this.queueList]);
+        const panel = $el("div", { style: { display: "flex", flexDirection: "column", minHeight: "0", flex: "1 1 auto" } }, [this.queueHeader, this.queueList]);
         return panel;
     }
 
@@ -504,6 +538,51 @@ class LinkerManagerDialog extends ComfyDialog {
             localStorage.setItem('model_linker_modal_pos', JSON.stringify({ top: Math.round(rect.top), left: Math.round(rect.left) }));
         } catch (e) { /* ignore */ }
         // Restore selection
+        try { document.body.style.userSelect = this._prevUserSelect || ''; } catch (e) {}
+    }
+
+    // Begin split drag for resizable panels
+    startSplitDrag(e) {
+        try {
+            if (!this.queueElement) return;
+            const rect = this.queueElement.getBoundingClientRect();
+            const body = document.getElementById('model-linker-body');
+            const bodyRect = body ? body.getBoundingClientRect() : { width: window.innerWidth };
+            this._splitDragging = true;
+            this._splitStart = {
+                x: e.clientX,
+                startWidth: rect.width,
+                containerWidth: bodyRect.width
+            };
+            this._prevUserSelect = document.body.style.userSelect;
+            document.body.style.userSelect = 'none';
+            this._onSplitMove = (ev) => this.onSplitDrag(ev);
+            this._onSplitUp = () => this.endSplitDrag();
+            document.addEventListener('mousemove', this._onSplitMove);
+            document.addEventListener('mouseup', this._onSplitUp, { once: true });
+        } catch (err) { /* ignore */ }
+    }
+
+    onSplitDrag(e) {
+        if (!this._splitDragging || !this._splitStart || !this.queueElement) return;
+        const dx = e.clientX - this._splitStart.x;
+        // Dragging right (dx>0) should decrease right panel width; left increases
+        let newW = this._splitStart.startWidth - dx;
+        const minW = 240;
+        const maxW = Math.max(minW, Math.floor(this._splitStart.containerWidth - 360));
+        if (newW < minW) newW = minW;
+        if (newW > maxW) newW = maxW;
+        this.queueElement.style.width = `${Math.round(newW)}px`;
+    }
+
+    endSplitDrag() {
+        if (!this._splitDragging) return;
+        this._splitDragging = false;
+        document.removeEventListener('mousemove', this._onSplitMove);
+        try {
+            const rect = this.queueElement.getBoundingClientRect();
+            localStorage.setItem('model_linker_split_w', String(Math.round(rect.width)));
+        } catch (e) {}
         try { document.body.style.userSelect = this._prevUserSelect || ''; } catch (e) {}
     }
 
@@ -787,6 +866,33 @@ class LinkerManagerDialog extends ComfyDialog {
             if (locateBtn && missing.is_top_level !== false) {
                 locateBtn.addEventListener('click', () => this.locateNodeInGraph(missing.node_id));
             }
+
+            // Apply saved size to search box and persist on resize
+            const searchBoxId = `searchbox-${missing.node_id}-${missing.widget_index}`;
+            const searchBox = container.querySelector(`#${searchBoxId}`);
+            if (searchBox) {
+                try {
+                    const saved = localStorage.getItem('model_linker_searchbox_size');
+                    if (saved) {
+                        const { w, h } = JSON.parse(saved);
+                        if (w && h) {
+                            searchBox.style.width = `${w}px`;
+                            searchBox.style.height = `${h}px`;
+                        }
+                    }
+                    if (window.ResizeObserver) {
+                        const ro = new ResizeObserver((entries) => {
+                            for (const entry of entries) {
+                                const rect = entry.target.getBoundingClientRect();
+                                const w = Math.round(rect.width);
+                                const h = Math.round(rect.height);
+                                localStorage.setItem('model_linker_searchbox_size', JSON.stringify({ w, h }));
+                            }
+                        });
+                        ro.observe(searchBox);
+                    }
+                } catch (e) { /* ignore */ }
+            }
         });
     }
 
@@ -924,11 +1030,14 @@ class LinkerManagerDialog extends ComfyDialog {
         const searchId = `search-all-${missing.node_id}-${missing.widget_index}`;
         const selectAllId = `select-all-${missing.node_id}-${missing.widget_index}`;
         const resolveAllId = `resolve-all-${missing.node_id}-${missing.widget_index}`;
-        html += `<div style="margin-top: 10px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">`;
+        const searchBoxId = `searchbox-${missing.node_id}-${missing.widget_index}`;
+        html += `<div style="margin-top: 10px; display: flex; gap: 8px; align-items: flex-start; flex-wrap: wrap;">`;
+        html += `<div id="${searchBoxId}" class="model-linker-searchbox" style="resize: both; overflow: auto; min-width: 260px; min-height: 140px; width: 360px; height: 200px; border: 1px solid var(--border-color); border-radius: 4px; padding: 8px; display: flex; flex-direction: column; gap: 6px; background: var(--comfy-input-bg, #2f2f2f);">`;
         html += `<label for="${searchId}" style="opacity: 0.9;">Search all models:</label>`;
-        html += `<input id="${searchId}" type="text" placeholder="type to filter..." style="min-width: 220px; padding: 4px;" />`;
-        html += `<select id="${selectAllId}" class="model-linker-select" size="8" style="min-width: 360px; max-width: 680px;"></select>`;
-        html += `<button id="${resolveAllId}" class="model-linker-resolve-btn" style="padding: 4px 8px;">Select from list</button>`;
+        html += `<input id="${searchId}" type="text" placeholder="type to filter..." style="padding: 4px; width: 100%; box-sizing: border-box;" />`;
+        html += `<select id="${selectAllId}" class="model-linker-select" size="8" style="flex: 1 1 auto; width: 100%; min-height: 0;"></select>`;
+        html += `</div>`;
+        html += `<button id="${resolveAllId}" class="model-linker-resolve-btn" style="padding: 4px 8px; height: 32px;">Select from list</button>`;
         html += `</div>`;
 
         html += '</div>';

--- a/web/linker.js
+++ b/web/linker.js
@@ -170,6 +170,25 @@ class LinkerManagerDialog extends ComfyDialog {
             ]),
             $el("div", { style: { display: "flex", gap: "8px", alignItems: "center" } }, [
                 $el("button", {
+                    id: "model-linker-overrides-btn",
+                    title: "Manage overrides",
+                    textContent: "Overrides",
+                    onclick: () => this.openOverridesManager(),
+                    style: {
+                        background: "none",
+                        border: "1px solid var(--border-color)",
+                        fontSize: "14px",
+                        cursor: "pointer",
+                        color: "var(--input-text)",
+                        padding: "2px 8px",
+                        height: "30px",
+                        borderRadius: "4px",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center"
+                    }
+                }),
+                $el("button", {
                     id: "model-linker-fullscreen-toggle",
                     title: "Toggle full screen",
                     textContent: "⛶",
@@ -333,6 +352,15 @@ class LinkerManagerDialog extends ComfyDialog {
             if (col === '1') this.setQueueCollapsed(true);
         } catch (e) {}
         return body;
+    }
+
+    openOverridesManager() {
+        try {
+            if (!this.overridesDialog) this.overridesDialog = new ManageOverridesDialog();
+            this.overridesDialog.show();
+        } catch (e) {
+            console.error('Model Linker: failed to open overrides dialog', e);
+        }
     }
 
     createQueuePanel() {
@@ -1654,6 +1682,189 @@ class LinkerManagerDialog extends ComfyDialog {
             // Don't throw - allow the workflow update to continue even if UI update fails
             // The backend has already updated the workflow data
         }
+    }
+}
+
+class ManageOverridesDialog extends ComfyDialog {
+    constructor() {
+        super();
+        this.data = null;
+        this.search = '';
+        this.element = $el("div.comfy-modal", {
+            parent: document.body,
+            style: {
+                position: "fixed",
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
+                width: "720px",
+                height: "520px",
+                maxWidth: "95vw",
+                maxHeight: "90vh",
+                backgroundColor: "var(--comfy-menu-bg, #202020)",
+                color: "var(--input-text, #ffffff)",
+                border: "2px solid var(--border-color, #555555)",
+                borderRadius: "8px",
+                padding: "0",
+                zIndex: "99999",
+                boxShadow: "0 4px 20px rgba(0,0,0,0.8)",
+                display: "none",
+                flexDirection: "column"
+            }
+        }, [
+            this._header(),
+            this._content(),
+            this._footer()
+        ]);
+    }
+
+    _header() {
+        return $el("div", {
+            style: {
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                padding: "12px 16px",
+                borderBottom: "1px solid var(--border-color)"
+            }
+        }, [
+            $el("h2", { textContent: "Manage Overrides", style: { margin: 0, fontSize: '16px' } }),
+            $el("button", { textContent: "×", onclick: () => this.close(), style: { background: 'none', border: 'none', fontSize: '20px', cursor: 'pointer', color: 'var(--input-text)' } })
+        ]);
+    }
+
+    _content() {
+        this.contentEl = $el("div", {
+            style: { padding: '12px', overflow: 'auto', flex: '1', minHeight: 0 }
+        }, [
+            $el("div", { style: { display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '8px' } }, [
+                $el("input", {
+                    id: 'ovr-search',
+                    placeholder: 'search overrides...',
+                    oninput: (e) => { this.search = e.target.value || ''; this.renderList(); },
+                    style: { flex: 1, padding: '6px' }
+                }),
+                $el("span", { id: 'ovr-count', textContent: '' })
+            ]),
+            this.listEl = $el("div", { id: 'ovr-list', style: { display: 'flex', flexDirection: 'column', gap: '6px' } })
+        ]);
+        return this.contentEl;
+    }
+
+    _footer() {
+        // Import
+        const fileInput = $el('input', { type: 'file', accept: '.json', style: { display: 'none' } });
+        const importBtn = $el('button', { className: 'model-linker-resolve-btn', textContent: 'Import JSON', onclick: () => fileInput.click(), style: { padding: '6px 10px' } });
+        fileInput.addEventListener('change', async (e) => {
+            const f = e.target.files && e.target.files[0];
+            if (!f) return;
+            try {
+                const text = await f.text();
+                const json = JSON.parse(text);
+                const resp = await api.fetchApi('/model_linker/overrides/replace', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ overrides: json }) });
+                const data = await resp.json();
+                if (data.success) {
+                    await this.load();
+                } else {
+                    alert('Import failed: ' + (data.error || 'unknown'));
+                }
+            } catch (err) {
+                alert('Invalid JSON: ' + err.message);
+            } finally {
+                e.target.value = '';
+            }
+        });
+
+        return $el("div", { style: { padding: '10px 12px', borderTop: '1px solid var(--border-color)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' } }, [
+            $el('div', { style: { display: 'flex', gap: '8px', alignItems: 'center' } }, [
+                $el('button', { className: 'model-linker-resolve-btn', textContent: 'Export JSON', onclick: () => this.export(), style: { padding: '6px 10px' } }),
+                importBtn,
+                fileInput
+            ]),
+            $el('div', { style: { display: 'flex', gap: '8px', alignItems: 'center' } }, [
+                $el('button', { className: 'model-linker-resolve-btn', textContent: 'Clear All', onclick: () => this.clearAll(), style: { padding: '6px 10px' } })
+            ])
+        ]);
+    }
+
+    async show() {
+        this.element.style.display = 'flex';
+        await this.load();
+    }
+
+    close() { this.element.style.display = 'none'; }
+
+    async load() {
+        try {
+            const resp = await api.fetchApi('/model_linker/overrides');
+            if (!resp.ok) throw new Error('HTTP ' + resp.status);
+            this.data = await resp.json();
+            this.renderList();
+        } catch (e) {
+            console.error('Overrides load error', e);
+            if (this.listEl) this.listEl.textContent = 'Error loading overrides';
+        }
+    }
+
+    renderList() {
+        if (!this.listEl) return;
+        const mappings = (this.data && this.data.overrides && this.data.overrides.mappings) || [];
+        const q = (this.search || '').toLowerCase();
+        const filtered = mappings.filter(m => {
+            const s = `${m.key || ''} ${m.original_filename || ''} ${m.category || ''} ${m.path || ''}`.toLowerCase();
+            return !q || s.includes(q);
+        });
+        const countEl = this.contentEl && this.contentEl.querySelector('#ovr-count');
+        if (countEl) countEl.textContent = `${filtered.length}/${mappings.length}`;
+        if (!filtered.length) {
+            this.listEl.innerHTML = '<div style="opacity:0.8;">No overrides</div>';
+            return;
+        }
+        let html = '';
+        for (const m of filtered) {
+            const delId = `ovr-del-${m.key}`.replace(/[^a-zA-Z0-9_-]/g, '_');
+            html += `<div style="border:1px solid var(--border-color); border-radius:4px; padding:8px; display:flex; gap:8px; align-items:center;">
+                <div style="flex: 2 1 40%; font-weight:600;"><code>${m.original_filename || ''}</code> <span style="opacity:.8;">[${m.category || 'any'}]</span></div>
+                <div style="flex: 3 1 60%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${m.path || ''}">${m.path || ''}</code></div>
+                <div><button id="${delId}" class="model-linker-resolve-btn" style="padding:4px 8px;">Delete</button></div>
+            </div>`;
+        }
+        this.listEl.innerHTML = html;
+        // Wire delete
+        for (const m of filtered) {
+            const delId = `ovr-del-${m.key}`.replace(/[^a-zA-Z0-9_-]/g, '_');
+            const btn = this.listEl.querySelector(`#${delId}`);
+            if (!btn) continue;
+            btn.addEventListener('click', async () => {
+                try {
+                    const resp = await api.fetchApi('/model_linker/overrides/delete', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ key: m.key }) });
+                    const data = await resp.json();
+                    if (data.success) await this.load(); else alert('Delete failed');
+                } catch (e) { alert('Delete failed: ' + e.message); }
+            });
+        }
+    }
+
+    async clearAll() {
+        try {
+            const resp = await api.fetchApi('/model_linker/overrides/clear', { method: 'POST' });
+            const data = await resp.json();
+            if (data.success) await this.load(); else alert('Clear failed');
+        } catch (e) { alert('Clear failed: ' + e.message); }
+    }
+
+    export() {
+        try {
+            const doc = (this.data && this.data.overrides) || { version: 1, mappings: [] };
+            const blob = new Blob([JSON.stringify(doc, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'overrides.json';
+            document.body.appendChild(a);
+            a.click();
+            setTimeout(() => { URL.revokeObjectURL(url); document.body.removeChild(a); }, 0);
+        } catch (e) { console.error('Export error', e); }
     }
 }
 

--- a/web/linker.js
+++ b/web/linker.js
@@ -1870,22 +1870,37 @@ class ManageOverridesDialog extends ComfyDialog {
                     <div style="flex:0 0 auto;"><button id="${delId}" class="model-linker-resolve-btn" style="padding:4px 8px;">Delete</button></div>
                 </div>
                 <div style="height:1px; background: var(--border-color); opacity:.5;"></div>
-                <div style="overflow-wrap:anywhere;"><code title="${m.path || ''}">${m.path || ''}</code></div>
+                <div style="display:flex; align-items:center; justify-content:space-between; gap:8px;">
+                    <div style="flex:1 1 auto; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${(m.path || '').split(/\\\\|\//).pop() || ''}">${(m.path || '').split(/\\\\|\//).pop() || ''}</code></div>
+                    <div style="flex:0 0 auto;"><button id="ovr-pathbtn-${(m.key || '').replace(/[^a-zA-Z0-9_-]/g, '_')}" class="model-linker-resolve-btn" style="padding:4px 8px;">Path</button></div>
+                </div>
+                <div id="ovr-pathrow-${(m.key || '').replace(/[^a-zA-Z0-9_-]/g, '_')}" style="display:none; overflow-wrap:anywhere; opacity:.9;"><code title="${m.path || ''}">${m.path || ''}</code></div>
             </div>`;
         }
         this.listEl.innerHTML = html;
-        // Wire delete
+        // Wire delete and path toggle
         for (const m of filtered) {
+            const safeKey = (m.key || '').replace(/[^a-zA-Z0-9_-]/g, '_');
             const delId = `ovr-del-${m.key}`.replace(/[^a-zA-Z0-9_-]/g, '_');
             const btn = this.listEl.querySelector(`#${delId}`);
-            if (!btn) continue;
-            btn.addEventListener('click', async () => {
-                try {
-                    const resp = await api.fetchApi('/model_linker/overrides/delete', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ key: m.key }) });
-                    const data = await resp.json();
-                    if (data.success) await this.load(); else alert('Delete failed');
-                } catch (e) { alert('Delete failed: ' + e.message); }
-            });
+            if (btn) {
+                btn.addEventListener('click', async () => {
+                    try {
+                        const resp = await api.fetchApi('/model_linker/overrides/delete', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ key: m.key }) });
+                        const data = await resp.json();
+                        if (data.success) await this.load(); else alert('Delete failed');
+                    } catch (e) { alert('Delete failed: ' + e.message); }
+                });
+            }
+            const pathBtn = this.listEl.querySelector(`#ovr-pathbtn-${safeKey}`);
+            const pathRow = this.listEl.querySelector(`#ovr-pathrow-${safeKey}`);
+            if (pathBtn && pathRow) {
+                pathBtn.addEventListener('click', () => {
+                    const vis = pathRow.style.display !== 'none';
+                    pathRow.style.display = vis ? 'none' : 'block';
+                    pathBtn.textContent = vis ? 'Path' : 'Hide path';
+                });
+            }
         }
     }
 

--- a/web/linker.js
+++ b/web/linker.js
@@ -89,6 +89,78 @@ class LinkerManagerDialog extends ComfyDialog {
             }
         } catch (e) { /* ignore */ }
 
+        // Enforce modal layout to be vertical (column) regardless of ComfyUI updates
+        // and make the model search input comfortably sized
+        try {
+            if (!document.getElementById('model-linker-style-layout')) {
+                const layoutStyle = $el("style", {
+                    id: 'model-linker-style-layout',
+                    textContent: `
+                        /* Force our modals to be column-oriented flex containers */
+                        #model-linker-modal,
+                        #manage-overrides-modal {
+                            flex-direction: column !important;
+                            align-items: stretch !important;
+                            white-space: normal !important;
+                        }
+
+                        /* Ensure text wraps normally inside content */
+                        #model-linker-content, #model-linker-content * { white-space: normal !important; }
+
+                        /* Strongly enforce vertical stacking for the missing list */
+                        #model-linker-modal #model-linker-content { display: block !important; }
+                        #model-linker-modal #model-linker-missing-list {
+                            display: flex !important;
+                            flex-direction: column !important;
+                            align-items: stretch !important;
+                            gap: 16px !important;
+                        }
+                        #model-linker-modal #model-linker-missing-list > div {
+                            display: block !important;
+                        }
+                        /* Make direct children inside each missing item stack vertically */
+                        #model-linker-modal #model-linker-missing-list > div > div,
+                        #model-linker-modal #model-linker-missing-list > div > p,
+                        #model-linker-modal #model-linker-missing-list > div > ul,
+                        #model-linker-modal #model-linker-missing-list > div > li {
+                            display: block !important;
+                            width: auto !important;
+                        }
+
+                        /* Stack each missing-model section vertically while keeping internal rows */
+                        #model-linker-content div[id^="missing-"] {
+                            display: flex !important;
+                            flex-direction: column !important;
+                            align-items: stretch !important;
+                        }
+
+                        /* Ensure the body/content area can actually grow */
+                        #model-linker-modal #model-linker-body,
+                        #manage-overrides-modal { min-height: 0 !important; }
+
+                        /* Make the model search input readable and not tiny */
+                        #model-linker-modal input[id^="combo-input-"] {
+                            flex: 1 1 auto !important;
+                            min-width: 240px !important;
+                            padding: 6px 8px !important;
+                            font-size: 13px !important;
+                        }
+
+                        /* Improve the dropdown list layering and sizing */
+                        #model-linker-modal div[id^="combo-list-"] {
+                            z-index: 100000 !important;
+                            max-height: 320px !important;
+                        }
+                        /* Avoid wrapping inside dropdown labels when sizing */
+                        #model-linker-modal div[id^="combo-list-"] code {
+                            white-space: nowrap !important;
+                        }
+                    `
+                });
+                document.head.appendChild(layoutStyle);
+            }
+        } catch (e) { /* ignore */ }
+
         // Apply saved size if present and persist future resizes
         try {
             const saved = localStorage.getItem('model_linker_modal_size');
@@ -841,7 +913,7 @@ class LinkerManagerDialog extends ComfyDialog {
         }
 
         let html = `<p><strong>Found ${totalMissing} missing model(s):</strong></p>`;
-        html += '<div style="display: flex; flex-direction: column; gap: 16px;">';
+        html += '<div id="model-linker-missing-list" style="display: flex; flex-direction: column; gap: 16px;">';
 
         // Sort missing models: those with 100% confidence matches first, then others
         const sortedMissingModels = missingModels.sort((a, b) => {
@@ -950,7 +1022,7 @@ class LinkerManagerDialog extends ComfyDialog {
         const filteredMatches = allMatches.filter(m => m.confidence >= 70);
         const hasMatches = filteredMatches.length > 0;
 
-        let html = `<div id="missing-${missing.node_id}-${missing.widget_index}" style="border: 1px solid var(--border-color, #444); padding: 12px; border-radius: 4px;">`;
+        let html = `<div id="missing-${missing.node_id}-${missing.widget_index}" style="border: 1px solid var(--border-color, #444); padding: 12px; border-radius: 4px; display:flex; flex-direction:column; align-items:stretch; gap:8px; white-space: normal;">`;
         
         // Display subgraph name as primary identifier if available, otherwise show node type
         // A node type that's a UUID indicates it's a subgraph instance
@@ -966,7 +1038,7 @@ class LinkerManagerDialog extends ComfyDialog {
             } else {
                 html += `<button id="${locateId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Locate</button>`;
             }
-            
+            html += `</div>`;
         } else if (isSubgraphNode) {
             // Node type is a UUID (subgraph) but we don't have the name (shouldn't happen, but handle gracefully)
             html += `<div style="margin-bottom: 8px; display:flex; align-items:center; justify-content:space-between; gap:8px;">`;
@@ -1065,11 +1137,7 @@ class LinkerManagerDialog extends ComfyDialog {
             html += `<div style="color: orange; margin-top: 8px;">No matches found.</div>`;
         }
 
-        // Always show a compact summary and the full-model search picker
-        html += `<div class="model-linker-missing-summary" style="margin: 8px 0; padding: 8px; border: 1px dashed var(--border-color, #444); border-radius: 4px; background: var(--comfy-input-bg, #2f2f2f);">`;
-        html += `<div><strong>Missing Model:</strong> <code>${missing.original_path}</code></div>`;
-        html += `<div><strong>Category:</strong> ${missing.category || 'unknown'}</div>`;
-        html += `</div>`;
+        // Compact summary removed (duplicate of info shown above)
 
         // combo picker injected via attachModelCombo
         
@@ -1463,7 +1531,7 @@ class LinkerManagerDialog extends ComfyDialog {
                 <input id="${inputId}" type="text" placeholder="type to filter..." style="flex:1; padding:4px;" />
                 <button id="${refreshId}" title="Refresh model list" class="model-linker-resolve-btn" style="padding:2px 8px;">⟳</button>
             </div>
-            <div id="${listId}" style="position:absolute; top:100%; left:0; right:0; background: var(--comfy-input-bg, #2f2f2f); border:1px solid var(--border-color); border-radius:4px; max-height:280px; overflow:auto; display:none; z-index:100000;"></div>
+            <div id="${listId}" style="position:absolute; top:100%; left:0; background: var(--comfy-input-bg, #2f2f2f); border:1px solid var(--border-color); border-radius:4px; max-height:280px; overflow:auto; display:none; z-index:100000;"></div>
         `;
         selectedBar.after(comboWrap);
 
@@ -1513,23 +1581,66 @@ class LinkerManagerDialog extends ComfyDialog {
         const buildSuggestions = (query) => {
             const pool = getPool();
             const q = (query || '').toLowerCase();
-            const items = pool.map(m => {
+            // Deduplicate by normalized label (relative_path || filename) to hide symlink duplicates
+            const bestByKey = new Map();
+            for (const m of pool) {
                 const label = m.relative_path || m.filename || '';
-                return { m, label, saved: savedPaths.has(m.path) };
-            }).filter(x => !q || (x.label || '').toLowerCase().includes(q));
+                const labelNorm = (label || '').toLowerCase().replace(/[\\/]+/g, '/');
+                if (q && !labelNorm.includes(q)) continue;
+                const saved = savedPaths.has(m.path);
+                const curr = bestByKey.get(labelNorm);
+                // Prefer a saved entry if available; otherwise keep the first
+                if (!curr || (saved && !curr.saved)) {
+                    bestByKey.set(labelNorm, { m, label, saved });
+                }
+            }
+            const items = Array.from(bestByKey.values());
             // sort: saved first, then label asc
             items.sort((a, b) => {
                 if (a.saved && !b.saved) return -1;
                 if (!a.saved && b.saved) return 1;
                 return (a.label || '').localeCompare(b.label || '');
             });
-            // limit to avoid giant DOM
-            return items.slice(0, 100).map(x => x.m);
+            // return all deduplicated items so user can scroll entire list
+            return items.map(x => x.m);
         };
 
         let currentItems = [];
         let activeIndex = -1;
-        const openList = () => { listEl.style.display = 'block'; };
+        // Align dropdown under input and size to fit longest item (min: input width)
+        const updateListPosition = () => {
+            try {
+                const wrapRect = comboWrap.getBoundingClientRect();
+                const inputRect = inputEl.getBoundingClientRect();
+                const left = Math.max(0, Math.round(inputRect.left - wrapRect.left));
+                const minW = Math.round(inputRect.width);
+                const prevDisplay = listEl.style.display;
+                const prevVis = listEl.style.visibility;
+                if (prevDisplay === 'none') {
+                    listEl.style.visibility = 'hidden';
+                    listEl.style.display = 'block';
+                }
+                const prevWidth = listEl.style.width;
+                listEl.style.width = 'auto';
+                // Prevent wrapping in labels when measuring
+                try {
+                    listEl.querySelectorAll('code').forEach(c => c.style.whiteSpace = 'nowrap');
+                } catch (e) {}
+                let contentW = Math.ceil(listEl.scrollWidth);
+                const viewportRight = window.innerWidth - 16;
+                const maxAllowed = Math.max(200, viewportRight - inputRect.left);
+                const finalW = Math.max(minW, Math.min(contentW || minW, maxAllowed));
+                listEl.style.left = left + 'px';
+                listEl.style.right = 'auto';
+                listEl.style.width = finalW + 'px';
+                if (prevDisplay === 'none') {
+                    listEl.style.display = prevDisplay;
+                    listEl.style.visibility = prevVis || '';
+                    listEl.style.width = prevWidth;
+                }
+            } catch (_) {}
+        };
+        const openList = () => { updateListPosition(); listEl.style.display = 'block'; };
         const closeList = () => { listEl.style.display = 'none'; activeIndex = -1; };
         const isOpen = () => listEl.style.display !== 'none';
 
@@ -1539,10 +1650,22 @@ class LinkerManagerDialog extends ComfyDialog {
             if (currentItems.length && activeIndex < 0) activeIndex = 0;
             if (!currentItems.length) activeIndex = -1;
             renderList(currentItems, q, activeIndex);
+            // Recompute width for new content
+            updateListPosition();
         };
 
         inputEl.addEventListener('focus', () => { openList(); updateList(); });
         inputEl.addEventListener('input', this.debounce(() => { updateList(); openList(); }, 120));
+        // Keep dropdown aligned on resize
+        window.addEventListener('resize', updateListPosition);
+        if (window.ResizeObserver) {
+            try {
+                const roPos = new ResizeObserver(() => updateListPosition());
+                roPos.observe(comboWrap);
+                roPos.observe(inputEl);
+                this._comboROs = (this._comboROs || []).concat(roPos);
+            } catch (e) { /* ignore */ }
+        }
         inputEl.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') { closeList(); return; }
             if (e.key === 'ArrowDown') {

--- a/web/linker.js
+++ b/web/linker.js
@@ -223,7 +223,8 @@ class LinkerManagerDialog extends ComfyDialog {
                 padding: "16px",
                 flex: "1",
                 minHeight: "0",
-                alignItems: "stretch"
+                alignItems: "stretch",
+                position: "relative"
             }
         });
 
@@ -286,6 +287,34 @@ class LinkerManagerDialog extends ComfyDialog {
             this.splitterElement.addEventListener('mousedown', onSplitMouseDown);
             this._splitterMouseDown = onSplitMouseDown;
         } catch (e) {}
+        // Toggle icon always visible
+        try {
+            this.queueToggleIcon = $el("button", {
+                id: "queue-toggle-icon",
+                title: "Collapse queue",
+                onclick: () => this.toggleQueueCollapsed(),
+                style: {
+                    position: "absolute",
+                    top: "50%",
+                    right: "6px",
+                    transform: "translateY(-50%)",
+                    zIndex: "1000",
+                    padding: "2px 6px",
+                    border: "1px solid var(--border-color)",
+                    borderRadius: "4px",
+                    background: "var(--comfy-input-bg, #2f2f2f)",
+                    cursor: "pointer",
+                    opacity: "0.9"
+                }
+            }, [document.createTextNode('⮜')]);
+            body.appendChild(this.queueToggleIcon);
+            this.updateQueueToggleIcon();
+        } catch (e) {}
+        // Restore queue collapsed state
+        try {
+            const col = localStorage.getItem('model_linker_queue_collapsed');
+            if (col === '1') this.setQueueCollapsed(true);
+        } catch (e) {}
         return body;
     }
 
@@ -300,13 +329,22 @@ class LinkerManagerDialog extends ComfyDialog {
             }
         }, [
             $el("div", { id: "queue-title", textContent: "Queued Selections (0)", style: { fontWeight: "600" } }),
-            $el("button", {
-                id: "queue-clear",
-                className: "model-linker-resolve-btn",
-                textContent: "Clear All",
-                onclick: () => this.clearAllQueued(),
-                style: { padding: "4px 8px" }
-            })
+            $el("div", { style: { display: "flex", gap: "6px" } }, [
+                $el("button", {
+                    id: "queue-toggle",
+                    className: "model-linker-resolve-btn",
+                    textContent: "Collapse",
+                    onclick: () => this.toggleQueueCollapsed(),
+                    style: { padding: "4px 8px" }
+                }),
+                $el("button", {
+                    id: "queue-clear",
+                    className: "model-linker-resolve-btn",
+                    textContent: "Clear All",
+                    onclick: () => this.clearAllQueued(),
+                    style: { padding: "4px 8px" }
+                })
+            ])
         ]);
 
         // Scrollable list
@@ -333,6 +371,8 @@ class LinkerManagerDialog extends ComfyDialog {
         // Update title count
         const title = this.queueHeader.querySelector('#queue-title');
         if (title) title.textContent = `Queued Selections (${list.length})`;
+        const toggleBtn = this.queueHeader.querySelector('#queue-toggle');
+        if (toggleBtn) toggleBtn.textContent = this.queueCollapsed ? 'Expand' : 'Collapse';
 
         if (!list.length) {
             this.queueList.innerHTML = '<div style="opacity:0.7;">No selections queued.</div>';
@@ -351,7 +391,7 @@ class LinkerManagerDialog extends ComfyDialog {
             html += `<div style="font-size:12px; opacity:0.9;">Original: <code>${orig}</code></div>`;
             html += `<div style="font-size:12px;">Selected: <code>${label}</code></div>`;
             html += `<div style="margin-top:6px;"><button id="${rmId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Remove</button></div>`;
-            html += `</div>`;
+            
         }
         html += '</div>';
         this.queueList.innerHTML = html;
@@ -390,6 +430,39 @@ class LinkerManagerDialog extends ComfyDialog {
         try {
             document.querySelectorAll('.model-linker-selected').forEach(el => { el.style.display = 'none'; el.innerHTML = ''; });
         } catch (e) { /* ignore */ }
+    }
+
+    // Collapse/expand queue panel and hide/show splitter
+    toggleQueueCollapsed() {
+        this.setQueueCollapsed(!this.queueCollapsed);
+    }
+
+    setQueueCollapsed(collapsed) {
+        this.queueCollapsed = !!collapsed;
+        if (!this.queueElement || !this.splitterElement) return;
+        if (this.queueCollapsed) {
+            this.queueElement.style.display = 'none';
+            this.splitterElement.style.display = 'none';
+            try { localStorage.setItem('model_linker_queue_collapsed', '1'); } catch (e) {}
+        } else {
+            this.queueElement.style.display = '';
+            this.splitterElement.style.display = '';
+            try { localStorage.setItem('model_linker_queue_collapsed', '0'); } catch (e) {}
+        }
+        this.updateQueuePanel();
+        this.updateQueueToggleIcon();
+    }
+
+    updateQueueToggleIcon() {
+        if (!this.queueToggleIcon) return;
+        if (this.queueCollapsed) {
+            this.queueToggleIcon.textContent = '⮞';
+            this.queueToggleIcon.title = 'Expand queue';
+            // keep at far right; nothing else to change
+        } else {
+            this.queueToggleIcon.textContent = '⮜';
+            this.queueToggleIcon.title = 'Collapse queue';
+        }
     }
     
     createFooter() {
@@ -806,57 +879,8 @@ class LinkerManagerDialog extends ComfyDialog {
                 }
             });
 
-            // Wire up all-models search + dropdown
-            const searchId = `search-all-${missing.node_id}-${missing.widget_index}`;
-            const selectAllId = `select-all-${missing.node_id}-${missing.widget_index}`;
-            const resolveAllId = `resolve-all-${missing.node_id}-${missing.widget_index}`;
-            const searchEl = container.querySelector(`#${searchId}`);
-            const selectAllEl = container.querySelector(`#${selectAllId}`);
-            const resolveAllBtn = container.querySelector(`#${resolveAllId}`);
-
-            const allModels = Array.isArray(this.allModels) ? this.allModels : [];
-            const buildLabel = (m) => `${m.category ? m.category + ': ' : ''}${m.relative_path || m.filename || ''}`;
-
-            const populateAllOptions = (filterText) => {
-                if (!selectAllEl) return;
-                const f = (filterText || '').toLowerCase();
-                const filtered = f
-                    ? allModels.filter(m => buildLabel(m).toLowerCase().includes(f))
-                    : allModels;
-                // Build options HTML
-                let opts = '';
-                for (let i = 0; i < filtered.length; i++) {
-                    const m = filtered[i];
-                    const label = buildLabel(m);
-                    // use index in allModels for value; keep stable mapping
-                    const valueIndex = allModels.indexOf(m);
-                    if (valueIndex >= 0) {
-                        opts += `<option value="${valueIndex}">${label}</option>`;
-                    }
-                }
-                selectAllEl.innerHTML = opts;
-            };
-
-            if (selectAllEl) {
-                populateAllOptions('');
-            }
-            if (searchEl) {
-                const debouncedFilter = this.debounce(() => {
-                    populateAllOptions(searchEl.value);
-                }, 250);
-                searchEl.addEventListener('input', debouncedFilter);
-            }
-            if (resolveAllBtn && selectAllEl) {
-                resolveAllBtn.addEventListener('click', () => {
-                    const idx = parseInt(selectAllEl.value, 10);
-                    if (!isNaN(idx) && idx >= 0 && idx < allModels.length) {
-                        const chosenModel = allModels[idx];
-                        if (chosenModel) {
-                            this.queueResolution(missing, chosenModel);
-                        }
-                    }
-                });
-            }
+            // Attach model combo picker (category-scoped)
+            this.attachModelCombo(container, missing);
             // Refresh selected UI for this item based on queued selections
             this.updateSelectedBarForMissing(missing);
 
@@ -867,32 +891,7 @@ class LinkerManagerDialog extends ComfyDialog {
                 locateBtn.addEventListener('click', () => this.locateNodeInGraph(missing.node_id));
             }
 
-            // Apply saved size to search box and persist on resize
-            const searchBoxId = `searchbox-${missing.node_id}-${missing.widget_index}`;
-            const searchBox = container.querySelector(`#${searchBoxId}`);
-            if (searchBox) {
-                try {
-                    const saved = localStorage.getItem('model_linker_searchbox_size');
-                    if (saved) {
-                        const { w, h } = JSON.parse(saved);
-                        if (w && h) {
-                            searchBox.style.width = `${w}px`;
-                            searchBox.style.height = `${h}px`;
-                        }
-                    }
-                    if (window.ResizeObserver) {
-                        const ro = new ResizeObserver((entries) => {
-                            for (const entry of entries) {
-                                const rect = entry.target.getBoundingClientRect();
-                                const w = Math.round(rect.width);
-                                const h = Math.round(rect.height);
-                                localStorage.setItem('model_linker_searchbox_size', JSON.stringify({ w, h }));
-                            }
-                        });
-                        ro.observe(searchBox);
-                    }
-                } catch (e) { /* ignore */ }
-            }
+            // Model combo is already attached above
         });
     }
 
@@ -918,17 +917,17 @@ class LinkerManagerDialog extends ComfyDialog {
             html += `<div style="margin-bottom: 8px; display:flex; align-items:center; justify-content:space-between; gap:8px;">`;
             html += `<span><strong>Subgraph:</strong> ${missing.subgraph_name} (ID: ${missing.node_id})</span>`;
             if (missing.is_top_level === false) {
-                html += `<button title="This node is inside a subgraph definition and can't be located in the main canvas" disabled class="model-linker-resolve-btn" style="opacity:.6; padding:2px 8px;">Locate</button>`;
+                html += `<button title="This node is inside a subgraph definition and can't be located in the main canvas" disabled class="model-linker-resolve-btn" style="opacity:.6; padding:2px 8px;">Located in subgraph</button>`;
             } else {
                 html += `<button id="${locateId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Locate</button>`;
             }
-            html += `</div>`;
+            
         } else if (isSubgraphNode) {
             // Node type is a UUID (subgraph) but we don't have the name (shouldn't happen, but handle gracefully)
             html += `<div style="margin-bottom: 8px; display:flex; align-items:center; justify-content:space-between; gap:8px;">`;
             html += `<span><strong>Node:</strong> <em>Subgraph</em> (ID: ${missing.node_id})</span>`;
             if (missing.is_top_level === false) {
-                html += `<button title="This node is inside a subgraph definition and can't be located in the main canvas" disabled class="model-linker-resolve-btn" style="opacity:.6; padding:2px 8px;">Locate</button>`;
+                html += `<button title="This node is inside a subgraph definition and can't be located in the main canvas" disabled class="model-linker-resolve-btn" style="opacity:.6; padding:2px 8px;">Located in subgraph</button>`;
             } else {
                 html += `<button id="${locateId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Locate</button>`;
             }
@@ -938,7 +937,7 @@ class LinkerManagerDialog extends ComfyDialog {
             html += `<div style="margin-bottom: 8px; display:flex; align-items:center; justify-content:space-between; gap:8px;">`;
             html += `<span><strong>Node:</strong> ${missing.node_type} (ID: ${missing.node_id})</span>`;
             if (missing.is_top_level === false) {
-                html += `<button title="This node is inside a subgraph definition and can't be located in the main canvas" disabled class="model-linker-resolve-btn" style="opacity:.6; padding:2px 8px;">Locate</button>`;
+                html += `<button title="This node is inside a subgraph definition and can't be located in the main canvas" disabled class="model-linker-resolve-btn" style="opacity:.6; padding:2px 8px;">Located in subgraph</button>`;
             } else {
                 html += `<button id="${locateId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Locate</button>`;
             }
@@ -1027,17 +1026,17 @@ class LinkerManagerDialog extends ComfyDialog {
         html += `<div><strong>Category:</strong> ${missing.category || 'unknown'}</div>`;
         html += `</div>`;
 
-        const searchId = `search-all-${missing.node_id}-${missing.widget_index}`;
-        const selectAllId = `select-all-${missing.node_id}-${missing.widget_index}`;
-        const resolveAllId = `resolve-all-${missing.node_id}-${missing.widget_index}`;
-        const searchBoxId = `searchbox-${missing.node_id}-${missing.widget_index}`;
-        html += `<div style="margin-top: 10px; display: flex; gap: 8px; align-items: flex-start; flex-wrap: wrap;">`;
-        html += `<div id="${searchBoxId}" class="model-linker-searchbox" style="resize: both; overflow: auto; min-width: 260px; min-height: 140px; width: 360px; height: 200px; border: 1px solid var(--border-color); border-radius: 4px; padding: 8px; display: flex; flex-direction: column; gap: 6px; background: var(--comfy-input-bg, #2f2f2f);">`;
-        html += `<label for="${searchId}" style="opacity: 0.9;">Search all models:</label>`;
-        html += `<input id="${searchId}" type="text" placeholder="type to filter..." style="padding: 4px; width: 100%; box-sizing: border-box;" />`;
-        html += `<select id="${selectAllId}" class="model-linker-select" size="8" style="flex: 1 1 auto; width: 100%; min-height: 0;"></select>`;
+        // combo picker injected via attachModelCombo
+        
+        
+        
+        
+        
+        
+        
+        
         html += `</div>`;
-        html += `<button id="${resolveAllId}" class="model-linker-resolve-btn" style="padding: 4px 8px; height: 32px;">Select from list</button>`;
+        
         html += `</div>`;
 
         html += '</div>';
@@ -1397,6 +1396,115 @@ class LinkerManagerDialog extends ComfyDialog {
         this.applyPendingBtn.style.opacity = n === 0 ? '0.6' : '1';
         // Keep the queue panel count in sync
         this.updateQueuePanel();
+    }
+
+    // Build and wire a node-like combo picker showing ALL models (not category-restricted)
+    attachModelCombo(container, missing) {
+        const category = null; // show all models regardless of category
+        const inputId = `combo-input-${missing.node_id}-${missing.widget_index}`;
+        const listId = `combo-list-${missing.node_id}-${missing.widget_index}`;
+        const refreshId = `combo-refresh-${missing.node_id}-${missing.widget_index}`;
+
+        // Inject combo markup after 'Selected' bar
+        const selectedBar = container.querySelector(`#selected-${missing.node_id}-${missing.widget_index}-${missing.subgraph_id || 'top'}`);
+        if (!selectedBar) return;
+        const comboWrap = document.createElement('div');
+        comboWrap.style.position = 'relative';
+        comboWrap.style.margin = '8px 0';
+        const catLabel = category ? ` (${category})` : '';
+        comboWrap.innerHTML = `
+            <div style="display:flex; align-items:center; gap:6px;">
+                <label style="opacity:0.9;">Model${catLabel}:</label>
+                <input id="${inputId}" type="text" placeholder="type to filter..." style="flex:1; padding:4px;" />
+                <button id="${refreshId}" title="Refresh model list" class="model-linker-resolve-btn" style="padding:2px 8px;">⟳</button>
+            </div>
+            <div id="${listId}" style="position:absolute; top:100%; left:0; right:0; background: var(--comfy-input-bg, #2f2f2f); border:1px solid var(--border-color); border-radius:4px; max-height:280px; overflow:auto; display:none; z-index:100000;"></div>
+        `;
+        selectedBar.after(comboWrap);
+
+        const inputEl = comboWrap.querySelector(`#${inputId}`);
+        const listEl = comboWrap.querySelector(`#${listId}`);
+        const refreshBtn = comboWrap.querySelector(`#${refreshId}`);
+        if (!inputEl || !listEl) return;
+
+        const savedPaths = new Set((missing.matches || []).filter(m => m.is_override && m.model && m.model.path).map(m => m.model.path));
+        const getPool = () => Array.isArray(this.allModels) ? this.allModels : [];
+
+        const renderList = (items) => {
+            if (!items || !items.length) {
+                listEl.innerHTML = '<div style="padding:6px; opacity:0.8;">No results</div>';
+                return;
+            }
+            let html = '';
+            for (let i = 0; i < items.length; i++) {
+                const m = items[i];
+                const label = m.relative_path || m.filename || '';
+                const isSaved = savedPaths.has(m.path);
+                html += `<div data-idx="${i}" style="padding:6px; display:flex; align-items:center; gap:6px; cursor:pointer;">
+                    <code style="flex:1;">${label}</code>
+                    ${isSaved ? '<span style="color:#0aa96e; font-weight:600;">(saved)</span>' : ''}
+                </div>`;
+            }
+            listEl.innerHTML = html;
+        };
+
+        const buildSuggestions = (query) => {
+            const pool = getPool();
+            const q = (query || '').toLowerCase();
+            const items = pool.map(m => {
+                const label = m.relative_path || m.filename || '';
+                return { m, label, saved: savedPaths.has(m.path) };
+            }).filter(x => !q || (x.label || '').toLowerCase().includes(q));
+            // sort: saved first, then label asc
+            items.sort((a, b) => {
+                if (a.saved && !b.saved) return -1;
+                if (!a.saved && b.saved) return 1;
+                return (a.label || '').localeCompare(b.label || '');
+            });
+            // limit to avoid giant DOM
+            return items.slice(0, 100).map(x => x.m);
+        };
+
+        const openList = () => { listEl.style.display = 'block'; };
+        const closeList = () => { listEl.style.display = 'none'; };
+        const isOpen = () => listEl.style.display !== 'none';
+
+        const updateList = () => {
+            const q = inputEl.value || '';
+            const items = buildSuggestions(q);
+            renderList(items);
+        };
+
+        inputEl.addEventListener('focus', () => { openList(); updateList(); });
+        inputEl.addEventListener('input', this.debounce(() => { updateList(); openList(); }, 120));
+        inputEl.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') { closeList(); return; }
+        });
+        listEl.addEventListener('mousedown', (e) => {
+            const item = e.target.closest('[data-idx]');
+            if (!item) return;
+            const idx = parseInt(item.getAttribute('data-idx'), 10);
+            const q = inputEl.value || '';
+            const items = buildSuggestions(q);
+            const chosen = items[idx];
+            if (chosen) {
+                this.queueResolution(missing, chosen);
+                inputEl.value = chosen.relative_path || chosen.filename || '';
+                closeList();
+            }
+        });
+        document.addEventListener('click', (e) => {
+            if (!comboWrap.contains(e.target)) closeList();
+        });
+        if (refreshBtn) {
+            refreshBtn.addEventListener('click', async () => {
+                try {
+                    const resp = await api.fetchApi('/model_linker/models');
+                    if (resp.ok) this.allModels = await resp.json();
+                } catch (e) {}
+                updateList(); openList();
+            });
+        }
     }
 
     // Center and select a node in the current graph by ID

--- a/web/linker.js
+++ b/web/linker.js
@@ -161,6 +161,39 @@ class LinkerManagerDialog extends ComfyDialog {
             }
         } catch (e) { /* ignore */ }
 
+        // Preview tooltip styles for model image hover previews
+        try {
+            if (!document.getElementById('model-linker-style-preview')) {
+                const previewStyle = $el("style", {
+                    id: 'model-linker-style-preview',
+                    textContent: `
+                        #model-linker-preview-tooltip {
+                            position: fixed;
+                            z-index: 200000;
+                            pointer-events: none;
+                            background: var(--comfy-menu-bg, #1a1a1a);
+                            border: 1px solid var(--border-color, #555);
+                            border-radius: 6px;
+                            padding: 4px;
+                            box-shadow: 0 4px 16px rgba(0,0,0,0.7);
+                            display: none;
+                            max-width: 320px;
+                            max-height: 320px;
+                        }
+                        #model-linker-preview-tooltip img,
+                        #model-linker-preview-tooltip video {
+                            display: block;
+                            max-width: 312px;
+                            max-height: 312px;
+                            object-fit: contain;
+                            border-radius: 4px;
+                        }
+                    `
+                });
+                document.head.appendChild(previewStyle);
+            }
+        } catch (e) { /* ignore */ }
+
         // Apply saved size if present and persist future resizes
         try {
             const saved = localStorage.getItem('model_linker_modal_size');
@@ -631,8 +664,88 @@ class LinkerManagerDialog extends ComfyDialog {
     }
 
     close() {
+        this._hidePreview();
         this.element.style.display = "none";
     }
+
+    // ── Preview tooltip helpers ──────────────────────────────────────
+
+    /** Lazily create the shared preview tooltip element. */
+    _getPreviewTooltip() {
+        if (this._previewTooltip) return this._previewTooltip;
+        const el = document.createElement('div');
+        el.id = 'model-linker-preview-tooltip';
+        document.body.appendChild(el);
+        this._previewTooltip = el;
+        return el;
+    }
+
+    /**
+     * Show a model preview image next to an anchor element.
+     * Falls back to <video> if <img> fails (for .mp4 previews).
+     */
+    _showPreview(category, relativePath, anchorEl) {
+        if (!category || !relativePath) return;
+        const tooltip = this._getPreviewTooltip();
+        const url = `/model_linker/preview?type=${encodeURIComponent(category)}&file=${encodeURIComponent(relativePath)}`;
+
+        // Try image first
+        const img = document.createElement('img');
+        img.src = url;
+        img.onload = () => {
+            tooltip.innerHTML = '';
+            tooltip.appendChild(img);
+            this._positionTooltip(tooltip, anchorEl);
+            tooltip.style.display = 'block';
+        };
+        img.onerror = () => {
+            // Might be a video preview (.mp4) – try <video>
+            const vid = document.createElement('video');
+            vid.src = url;
+            vid.autoplay = true;
+            vid.loop = true;
+            vid.muted = true;
+            vid.playsInline = true;
+            vid.onloadeddata = () => {
+                tooltip.innerHTML = '';
+                tooltip.appendChild(vid);
+                this._positionTooltip(tooltip, anchorEl);
+                tooltip.style.display = 'block';
+            };
+            vid.onerror = () => {
+                // No preview available – keep hidden
+                tooltip.style.display = 'none';
+            };
+        };
+    }
+
+    /** Position the tooltip to the right of the anchor, clamped to viewport. */
+    _positionTooltip(tooltip, anchorEl) {
+        const rect = anchorEl.getBoundingClientRect();
+        let left = rect.right + 8;
+        let top = rect.top;
+
+        // Clamp to viewport
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        if (left + 330 > vw) left = rect.left - 330;
+        if (left < 0) left = 4;
+        if (top + 330 > vh) top = vh - 334;
+        if (top < 0) top = 4;
+
+        tooltip.style.left = left + 'px';
+        tooltip.style.top = top + 'px';
+    }
+
+    /** Hide the preview tooltip. */
+    _hidePreview() {
+        if (this._previewTooltip) {
+            this._previewTooltip.style.display = 'none';
+            this._previewTooltip.innerHTML = '';
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────
 
     /**
      * Ensure all models are loaded for the dropdown.
@@ -993,6 +1106,16 @@ class LinkerManagerDialog extends ComfyDialog {
                     resolveButton.addEventListener('click', () => {
                         this.queueResolution(missing, match.model);
                     });
+                    // Preview on hover over the match <li>
+                    const liEl = resolveButton.closest('li');
+                    if (liEl && match.model) {
+                        liEl.addEventListener('mouseenter', () => {
+                            this._showPreview(match.model.category || missing.category, match.model.relative_path || match.model.filename, liEl);
+                        });
+                        liEl.addEventListener('mouseleave', () => {
+                            this._hidePreview();
+                        });
+                    }
                 }
             });
 
@@ -1346,6 +1469,7 @@ class LinkerManagerDialog extends ComfyDialog {
             original_path: missing.original_path,
             subgraph_id: missing.subgraph_id,
             is_top_level: missing.is_top_level,
+            nested_key: missing.nested_key || null,
             node_type: missing.node_type,
             node_label: missing.subgraph_name || missing.node_type
         };
@@ -1407,8 +1531,9 @@ class LinkerManagerDialog extends ComfyDialog {
                         category: missing.category,
                         resolved_model: perfectMatch.model,
                         original_path: missing.original_path,
-                        subgraph_id: missing.subgraph_id,  // Include subgraph_id for subgraph nodes
-                        is_top_level: missing.is_top_level  // True for top-level nodes, False for nodes in subgraph definitions
+                        subgraph_id: missing.subgraph_id,
+                        is_top_level: missing.is_top_level,
+                        nested_key: missing.nested_key || null
                     });
                 }
             }
@@ -1641,7 +1766,7 @@ class LinkerManagerDialog extends ComfyDialog {
             } catch (_) { }
         };
         const openList = () => { updateListPosition(); listEl.style.display = 'block'; };
-        const closeList = () => { listEl.style.display = 'none'; activeIndex = -1; };
+        const closeList = () => { listEl.style.display = 'none'; activeIndex = -1; this._hidePreview(); };
         const isOpen = () => listEl.style.display !== 'none';
 
         const updateList = () => {
@@ -1706,6 +1831,22 @@ class LinkerManagerDialog extends ComfyDialog {
                 this.queueResolution(missing, chosen);
                 inputEl.value = chosen.relative_path || chosen.filename || '';
                 closeList();
+            }
+        });
+        // Preview on hover over dropdown items (event delegation)
+        listEl.addEventListener('mouseover', (e) => {
+            const item = e.target.closest('[data-idx]');
+            if (!item) return;
+            const idx = parseInt(item.getAttribute('data-idx'), 10);
+            const model = currentItems[idx];
+            if (model) {
+                this._showPreview(model.category || missing.category, model.relative_path || model.filename, item);
+            }
+        });
+        listEl.addEventListener('mouseout', (e) => {
+            const item = e.target.closest('[data-idx]');
+            if (item && !item.contains(e.relatedTarget)) {
+                this._hidePreview();
             }
         });
         document.addEventListener('click', (e) => {
@@ -1831,10 +1972,17 @@ class LinkerManagerDialog extends ComfyDialog {
                     }
 
                     if (node.widgets && node.widgets[widgetIndex]) {
-                        node.widgets[widgetIndex].value = newValue;
+                        const widget = node.widgets[widgetIndex];
+                        // For nested dict widgets (e.g. Power Lora Loader), update only the
+                        // specific key to preserve other properties (on, strength, etc.)
+                        if (res.nested_key && widget.value && typeof widget.value === 'object' && typeof newValue === 'object') {
+                            widget.value[res.nested_key] = newValue[res.nested_key];
+                        } else {
+                            widget.value = newValue;
+                        }
                         // Trigger widget callback if available (updates combo dropdowns, etc.)
-                        if (typeof node.widgets[widgetIndex].callback === 'function') {
-                            try { node.widgets[widgetIndex].callback(newValue); } catch (_) { /* ignore */ }
+                        if (typeof widget.callback === 'function') {
+                            try { widget.callback(widget.value); } catch (_) { /* ignore */ }
                         }
                         updatedCount++;
                     }

--- a/web/linker.js
+++ b/web/linker.js
@@ -33,6 +33,9 @@ class LinkerManagerDialog extends ComfyDialog {
         super();
         this.currentWorkflow = null;
         this.missingModels = [];
+        this.allModels = null; // list of all available models for dropdown
+        this.pendingResolutions = [];
+        this.pendingIndex = new Map(); // key -> index in pendingResolutions
         
         // Create dialog element using $el
         this.element = $el("div.comfy-modal", {
@@ -118,7 +121,8 @@ class LinkerManagerDialog extends ComfyDialog {
     }
     
     createFooter() {
-        return $el("div", {
+        // Create buttons container
+        const footer = $el("div", {
             style: {
                 padding: "16px",
                 borderTop: "1px solid var(--border-color)",
@@ -126,25 +130,77 @@ class LinkerManagerDialog extends ComfyDialog {
                 justifyContent: "flex-end",
                 gap: "8px"
             }
-        }, [
-            $el("button", {
-                textContent: "Auto-Resolve 100% Matches",
-                onclick: () => this.autoResolve100Percent(),
-                className: "comfy-button",
-                style: {
-                    padding: "8px 16px"
-                }
-            })
-        ]);
+        });
+
+        // Auto resolve 100%
+        const autoBtn = $el("button", {
+            textContent: "Auto-Resolve 100% Matches",
+            onclick: () => this.autoResolve100Percent(),
+            className: "comfy-button",
+            style: {
+                padding: "8px 16px"
+            }
+        });
+
+        // Apply pending resolutions
+        this.applyPendingBtn = $el("button", {
+            id: "apply-pending-resolutions",
+            textContent: "Apply Selected (0)",
+            className: "comfy-button",
+            onclick: () => this.applyPendingResolutions(),
+            style: {
+                padding: "8px 16px"
+            }
+        });
+
+        footer.appendChild(this.applyPendingBtn);
+        footer.appendChild(autoBtn);
+        return footer;
     }
     
     async show() {
         this.element.style.display = "flex";
+        await this.ensureAllModelsLoaded();
         await this.loadWorkflowData();
     }
     
     close() {
         this.element.style.display = "none";
+    }
+
+    /**
+     * Ensure all models are loaded for the dropdown.
+     */
+    async ensureAllModelsLoaded() {
+        if (this.allModels && this.allModels.length) return;
+        try {
+            const resp = await api.fetchApi('/model_linker/models');
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            const models = await resp.json();
+            const list = Array.isArray(models) ? models : [];
+            // Build labels and sort alphabetically
+            this.allModels = list.map((m) => ({
+                ...m,
+                __label: `${m.category ? m.category + ': ' : ''}${m.relative_path || m.filename || ''}`
+            })).sort((a, b) => (a.__label || '').localeCompare(b.__label || ''));
+        } catch (e) {
+            console.warn('Model Linker: could not load all models', e);
+            this.allModels = [];
+        }
+    }
+
+    /**
+     * Simple debounce helper: returns a function that waits for `wait` ms after
+     * the last call before invoking `callback`.
+     */
+    debounce(callback, wait = 250) {
+        let t = null;
+        return (...args) => {
+            if (t) clearTimeout(t);
+            t = setTimeout(() => {
+                callback.apply(this, args);
+            }, wait);
+        };
     }
 
     /**
@@ -265,9 +321,24 @@ class LinkerManagerDialog extends ComfyDialog {
             const otherMatches = filteredMatches.filter(m => m.confidence < 100 && m.confidence >= 70);
             
             // Match the same logic as renderMissingModel
-            const matchesToShow = perfectMatches.length > 0 
-                ? perfectMatches 
-                : otherMatches.sort((a, b) => b.confidence - a.confidence).slice(0, 5);
+            const savedMatches = filteredMatches.filter(m => m.is_override);
+            let matchesToShow = null;
+            if (perfectMatches.length > 0) {
+                // Show 100% matches, but always include saved matches as well
+                const combined = [...perfectMatches];
+                for (const sm of savedMatches) {
+                    const p = sm.model?.path;
+                    if (!combined.some(x => x.model?.path === p)) combined.push(sm);
+                }
+                matchesToShow = combined;
+            } else {
+                matchesToShow = otherMatches.sort((a, b) => b.confidence - a.confidence).slice(0, 5);
+                // Ensure saved matches are included even if outside top 5
+                for (const sm of savedMatches) {
+                    const p = sm.model?.path;
+                    if (!matchesToShow.some(x => x.model?.path === p)) matchesToShow.push(sm);
+                }
+            }
             
             // Sort: 100% matches first, then by confidence descending (same as renderMissingModel)
             const sortedMatches = matchesToShow.sort((a, b) => {
@@ -276,21 +347,68 @@ class LinkerManagerDialog extends ComfyDialog {
                 return b.confidence - a.confidence;
             });
             
-            // Find the highest confidence match (even if not 100%)
-            const highestConfidenceMatch = sortedMatches.length > 0 ? sortedMatches[0] : null;
-            
+            // Attach listener for all displayed matches so the user can pick explicitly
             sortedMatches.forEach((match, matchIndex) => {
-                // Only attach listener if this match would have a button (100% or highest confidence)
-                if (match.confidence === 100 || match === highestConfidenceMatch) {
-                    const buttonId = `resolve-${missing.node_id}-${missing.widget_index}-${matchIndex}`;
-                    const resolveButton = container.querySelector(`#${buttonId}`);
-                    if (resolveButton) {
-                        resolveButton.addEventListener('click', () => {
-                            this.resolveModel(missing, match.model);
-                        });
-                    }
+                const buttonId = `resolve-${missing.node_id}-${missing.widget_index}-${matchIndex}`;
+                const resolveButton = container.querySelector(`#${buttonId}`);
+                if (resolveButton) {
+                    resolveButton.addEventListener('click', () => {
+                        this.queueResolution(missing, match.model);
+                    });
                 }
             });
+
+            // Wire up all-models search + dropdown
+            const searchId = `search-all-${missing.node_id}-${missing.widget_index}`;
+            const selectAllId = `select-all-${missing.node_id}-${missing.widget_index}`;
+            const resolveAllId = `resolve-all-${missing.node_id}-${missing.widget_index}`;
+            const searchEl = container.querySelector(`#${searchId}`);
+            const selectAllEl = container.querySelector(`#${selectAllId}`);
+            const resolveAllBtn = container.querySelector(`#${resolveAllId}`);
+
+            const allModels = Array.isArray(this.allModels) ? this.allModels : [];
+            const buildLabel = (m) => `${m.category ? m.category + ': ' : ''}${m.relative_path || m.filename || ''}`;
+
+            const populateAllOptions = (filterText) => {
+                if (!selectAllEl) return;
+                const f = (filterText || '').toLowerCase();
+                const filtered = f
+                    ? allModels.filter(m => buildLabel(m).toLowerCase().includes(f))
+                    : allModels;
+                // Build options HTML
+                let opts = '';
+                for (let i = 0; i < filtered.length; i++) {
+                    const m = filtered[i];
+                    const label = buildLabel(m);
+                    // use index in allModels for value; keep stable mapping
+                    const valueIndex = allModels.indexOf(m);
+                    if (valueIndex >= 0) {
+                        opts += `<option value="${valueIndex}">${label}</option>`;
+                    }
+                }
+                selectAllEl.innerHTML = opts;
+            };
+
+            if (selectAllEl) {
+                populateAllOptions('');
+            }
+            if (searchEl) {
+                const debouncedFilter = this.debounce(() => {
+                    populateAllOptions(searchEl.value);
+                }, 250);
+                searchEl.addEventListener('input', debouncedFilter);
+            }
+            if (resolveAllBtn && selectAllEl) {
+                resolveAllBtn.addEventListener('click', () => {
+                    const idx = parseInt(selectAllEl.value, 10);
+                    if (!isNaN(idx) && idx >= 0 && idx < allModels.length) {
+                        const chosenModel = allModels[idx];
+                        if (chosenModel) {
+                            this.queueResolution(missing, chosenModel);
+                        }
+                    }
+                });
+            }
         });
     }
 
@@ -304,7 +422,7 @@ class LinkerManagerDialog extends ComfyDialog {
         const filteredMatches = allMatches.filter(m => m.confidence >= 70);
         const hasMatches = filteredMatches.length > 0;
 
-        let html = `<div style="border: 1px solid var(--border-color, #444); padding: 12px; border-radius: 4px;">`;
+        let html = `<div id="missing-${missing.node_id}-${missing.widget_index}" style="border: 1px solid var(--border-color, #444); padding: 12px; border-radius: 4px;">`;
         
         // Display subgraph name as primary identifier if available, otherwise show node type
         // A node type that's a UUID indicates it's a subgraph instance
@@ -331,10 +449,23 @@ class LinkerManagerDialog extends ComfyDialog {
             const perfectMatches = filteredMatches.filter(m => m.confidence === 100);
             const otherMatches = filteredMatches.filter(m => m.confidence < 100 && m.confidence >= 70);
             
-            // If we have 100% matches, only show those. Otherwise, show other matches sorted by confidence
-            const matchesToShow = perfectMatches.length > 0 
-                ? perfectMatches 
-                : otherMatches.sort((a, b) => b.confidence - a.confidence).slice(0, 5);
+            // If we have 100% matches, show them AND always include saved matches as well.
+            const savedMatches = filteredMatches.filter(m => m.is_override);
+            let matchesToShow = null;
+            if (perfectMatches.length > 0) {
+                const combined = [...perfectMatches];
+                for (const sm of savedMatches) {
+                    const p = sm.model?.path;
+                    if (!combined.some(x => x.model?.path === p)) combined.push(sm);
+                }
+                matchesToShow = combined;
+            } else {
+                matchesToShow = otherMatches.sort((a, b) => b.confidence - a.confidence).slice(0, 5);
+                for (const sm of savedMatches) {
+                    const p = sm.model?.path;
+                    if (!matchesToShow.some(x => x.model?.path === p)) matchesToShow.push(sm);
+                }
+            }
             
             html += `<div style="margin-top: 12px;"><strong>Suggested Matches:</strong></div>`;
             html += '<ul style="margin: 8px 0; padding-left: 20px;">';
@@ -353,17 +484,18 @@ class LinkerManagerDialog extends ComfyDialog {
                 const match = sortedMatches[matchIndex];
                 const buttonId = `resolve-${missing.node_id}-${missing.widget_index}-${matchIndex}`;
                 html += `<li style="margin: 4px 0;">`;
-                html += `<code>${match.model?.relative_path || match.filename}</code> `;
-                html += `<span style="color: ${match.confidence === 100 ? 'green' : 'orange'};">
-                    (${match.confidence}% confidence)
-                </span>`;
-                // Show resolve button for 100% matches OR for the highest confidence match (even if not 100%)
-                if (match.confidence === 100 || match === highestConfidenceMatch) {
-                    html += ` <button id="${buttonId}" 
-                        class="model-linker-resolve-btn" style="margin-left: 8px; padding: 4px 8px;">
-                        Resolve
-                    </button>`;
+                const label = match.model?.relative_path || match.filename;
+                const isSaved = !!match.is_override;
+                html += `<code>${label}</code> `;
+                html += `<span style="color: ${match.confidence === 100 ? 'green' : 'orange'};">\n                    (${match.confidence}% confidence)\n                </span>`;
+                if (isSaved) {
+                    html += ` <span style="color:#0aa96e; font-weight:600;">(saved)</span>`;
                 }
+                // Always provide a Resolve button so the user can pick explicitly
+                html += ` <button id="${buttonId}" 
+                        class="model-linker-resolve-btn" style="margin-left: 8px; padding: 4px 8px;">
+                        Select
+                    </button>`;
                 html += `</li>`;
             }
             
@@ -379,6 +511,22 @@ class LinkerManagerDialog extends ComfyDialog {
         } else {
             html += `<div style="color: orange; margin-top: 8px;">No matches found.</div>`;
         }
+
+        // Always show a compact summary and the full-model search picker
+        html += `<div class="model-linker-missing-summary" style="margin: 8px 0; padding: 8px; border: 1px dashed var(--border-color, #444); border-radius: 4px; background: var(--comfy-input-bg, #2f2f2f);">`;
+        html += `<div><strong>Missing Model:</strong> <code>${missing.original_path}</code></div>`;
+        html += `<div><strong>Category:</strong> ${missing.category || 'unknown'}</div>`;
+        html += `</div>`;
+
+        const searchId = `search-all-${missing.node_id}-${missing.widget_index}`;
+        const selectAllId = `select-all-${missing.node_id}-${missing.widget_index}`;
+        const resolveAllId = `resolve-all-${missing.node_id}-${missing.widget_index}`;
+        html += `<div style="margin-top: 10px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">`;
+        html += `<label for="${searchId}" style="opacity: 0.9;">Search all models:</label>`;
+        html += `<input id="${searchId}" type="text" placeholder="type to filter..." style="min-width: 220px; padding: 4px;" />`;
+        html += `<select id="${selectAllId}" class="model-linker-select" size="8" style="min-width: 360px; max-width: 680px;"></select>`;
+        html += `<button id="${resolveAllId}" class="model-linker-resolve-btn" style="padding: 4px 8px;">Select from list</button>`;
+        html += `</div>`;
 
         html += '</div>';
         return html;
@@ -498,65 +646,49 @@ class LinkerManagerDialog extends ComfyDialog {
     }
 
     /**
-     * Resolve a single model
+     * Queue a single resolution (do not call backend yet)
      */
-    async resolveModel(missing, resolvedModel) {
+    queueResolution(missing, resolvedModel) {
         if (!resolvedModel) {
-            this.showNotification('No resolved model selected', 'error');
+            this.showNotification('No model selected', 'error');
             return;
         }
 
-        try {
-            const workflow = this.getCurrentWorkflow();
-            if (!workflow) {
-                this.showNotification('No workflow loaded', 'error');
-                return;
-            }
+        const resolution = {
+            node_id: missing.node_id,
+            widget_index: missing.widget_index,
+            resolved_path: resolvedModel.path,
+            category: missing.category,
+            resolved_model: resolvedModel,
+            original_path: missing.original_path,
+            subgraph_id: missing.subgraph_id,
+            is_top_level: missing.is_top_level
+        };
 
-            const resolution = {
-                node_id: missing.node_id,
-                widget_index: missing.widget_index,
-                resolved_path: resolvedModel.path,
-                category: missing.category,
-                resolved_model: resolvedModel,
-                subgraph_id: missing.subgraph_id,  // Include subgraph_id for subgraph nodes
-                is_top_level: missing.is_top_level  // True for top-level nodes, False for nodes in subgraph definitions
-            };
-
-            const response = await api.fetchApi('/model_linker/resolve', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    workflow,
-                    resolutions: [resolution]
-                })
-            });
-
-            if (!response.ok) {
-                throw new Error(`API error: ${response.status}`);
-            }
-
-            const data = await response.json();
-            
-            if (data.success) {
-                // Update workflow in ComfyUI
-                await this.updateWorkflowInComfyUI(data.workflow);
-                
-                // Show success notification
-                const modelName = resolvedModel.relative_path || resolvedModel.filename || 'model';
-                this.showNotification(`✓ Model linked successfully: ${modelName}`, 'success');
-                
-                // Reload dialog using the updated workflow from API response
-                // This ensures we're analyzing the correct updated workflow
-                await this.loadWorkflowData(data.workflow);
-            } else {
-                this.showNotification('Failed to resolve model: ' + (data.error || 'Unknown error'), 'error');
-            }
-
-        } catch (error) {
-            console.error('Model Linker: Error resolving model:', error);
-            this.showNotification('Error resolving model: ' + error.message, 'error');
+        const key = `${resolution.node_id}:${resolution.widget_index}:${resolution.subgraph_id || ''}:${resolution.is_top_level ? 'T' : 'F'}`;
+        if (this.pendingIndex.has(key)) {
+            // replace existing selection for this slot
+            const idx = this.pendingIndex.get(key);
+            this.pendingResolutions[idx] = resolution;
+        } else {
+            this.pendingIndex.set(key, this.pendingResolutions.length);
+            this.pendingResolutions.push(resolution);
         }
+
+        // Mark block as queued
+        try {
+            const blockId = `missing-${missing.node_id}-${missing.widget_index}`;
+            const block = document.getElementById(blockId);
+            if (block && !block.querySelector('.queued-badge')) {
+                const badge = document.createElement('div');
+                badge.className = 'queued-badge';
+                badge.style.cssText = 'margin-top:8px;color:#0aa96e;font-weight:600;';
+                badge.textContent = 'Queued for linking';
+                block.appendChild(badge);
+            }
+        } catch (e) { /* ignore DOM errors */ }
+
+        this.updateApplyPendingButton();
     }
 
     /**
@@ -599,6 +731,7 @@ class LinkerManagerDialog extends ComfyDialog {
                         resolved_path: perfectMatch.model.path,
                         category: missing.category,
                         resolved_model: perfectMatch.model,
+                        original_path: missing.original_path,
                         subgraph_id: missing.subgraph_id,  // Include subgraph_id for subgraph nodes
                         is_top_level: missing.is_top_level  // True for top-level nodes, False for nodes in subgraph definitions
                     });
@@ -647,6 +780,57 @@ class LinkerManagerDialog extends ComfyDialog {
             console.error('Model Linker: Error auto-resolving:', error);
             this.showNotification('Error auto-resolving: ' + error.message, 'error');
         }
+    }
+
+    /**
+     * Apply all queued resolutions in a single backend call
+     */
+    async applyPendingResolutions() {
+        const list = this.pendingResolutions || [];
+        if (!list.length) {
+            this.showNotification('No selections queued', 'error');
+            return;
+        }
+
+        try {
+            const workflow = this.getCurrentWorkflow();
+            if (!workflow) {
+                this.showNotification('No workflow loaded', 'error');
+                return;
+            }
+
+            const response = await api.fetchApi('/model_linker/resolve', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ workflow, resolutions: list })
+            });
+
+            if (!response.ok) throw new Error(`API error: ${response.status}`);
+
+            const data = await response.json();
+            if (data.success) {
+                await this.updateWorkflowInComfyUI(data.workflow);
+                this.showNotification(`✓ Linked ${list.length} selection${list.length>1?'s':''}`, 'success');
+                // Clear queue and refresh analysis
+                this.pendingResolutions = [];
+                this.pendingIndex = new Map();
+                this.updateApplyPendingButton();
+                await this.loadWorkflowData(data.workflow);
+            } else {
+                this.showNotification('Failed to apply selections: ' + (data.error || 'Unknown error'), 'error');
+            }
+        } catch (e) {
+            console.error('Model Linker: applyPendingResolutions error', e);
+            this.showNotification('Error applying selections: ' + e.message, 'error');
+        }
+    }
+
+    updateApplyPendingButton() {
+        if (!this.applyPendingBtn) return;
+        const n = (this.pendingResolutions || []).length;
+        this.applyPendingBtn.textContent = `Apply Selected (${n})`;
+        this.applyPendingBtn.disabled = n === 0;
+        this.applyPendingBtn.style.opacity = n === 0 ? '0.6' : '1';
     }
 
     /**
@@ -887,4 +1071,3 @@ app.registerExtension({
     name: "Model Linker",
     setup: modelLinker.setup
 });
-

--- a/web/linker.js
+++ b/web/linker.js
@@ -42,6 +42,7 @@ class LinkerManagerDialog extends ComfyDialog {
         
         // Create dialog element using $el
         this.element = $el("div.comfy-modal", {
+            id: "model-linker-modal",
             parent: document.body,
             style: {
                 position: "fixed",
@@ -71,6 +72,22 @@ class LinkerManagerDialog extends ComfyDialog {
             this.createContent(),
             this.createFooter()
         ]);
+
+        // Inject style to reduce button font-size by 2px within this modal
+        try {
+            if (!document.getElementById('model-linker-style-buttons')) {
+                const style = $el("style", {
+                    id: 'model-linker-style-buttons',
+                    textContent: `
+                        #model-linker-modal .model-linker-resolve-btn,
+                        #model-linker-modal .comfy-button {
+                            font-size: calc(1em - 2px);
+                        }
+                    `
+                });
+                document.head.appendChild(style);
+            }
+        } catch (e) { /* ignore */ }
 
         // Apply saved size if present and persist future resizes
         try {
@@ -491,7 +508,7 @@ class LinkerManagerDialog extends ComfyDialog {
         this.applyPendingBtn = $el("button", {
             id: "apply-pending-resolutions",
             textContent: "Apply Selected (0)",
-            className: "comfy-button",
+            className: "comfy-button model-linker-resolve-btn",
             onclick: () => this.applyPendingResolutions(),
             style: {
                 padding: "8px 16px"

--- a/web/linker.js
+++ b/web/linker.js
@@ -1691,6 +1691,7 @@ class ManageOverridesDialog extends ComfyDialog {
         this.data = null;
         this.search = '';
         this.element = $el("div.comfy-modal", {
+            id: 'manage-overrides-modal',
             parent: document.body,
             style: {
                 position: "fixed",
@@ -1709,13 +1710,47 @@ class ManageOverridesDialog extends ComfyDialog {
                 zIndex: "99999",
                 boxShadow: "0 4px 20px rgba(0,0,0,0.8)",
                 display: "none",
-                flexDirection: "column"
+                flexDirection: "column",
+                resize: "both",
+                overflow: "hidden",
+                minWidth: "560px",
+                minHeight: "360px"
             }
         }, [
             this._header(),
             this._content(),
             this._footer()
         ]);
+
+        // Persist window size for overrides dialog
+        try {
+            const saved = localStorage.getItem('model_linker_overrides_size');
+            if (saved) {
+                const { w, h } = JSON.parse(saved);
+                if (w && h) { this.element.style.width = `${w}px`; this.element.style.height = `${h}px`; }
+            }
+            if (window.ResizeObserver) {
+                const ro = new ResizeObserver((entries) => {
+                    for (const entry of entries) {
+                        const rect = entry.target.getBoundingClientRect();
+                        localStorage.setItem('model_linker_overrides_size', JSON.stringify({ w: Math.round(rect.width), h: Math.round(rect.height) }));
+                    }
+                });
+                ro.observe(this.element);
+                this._ro = ro;
+            }
+        } catch (e) {}
+
+        // Scoped smaller button font-size (2px less) in overrides modal
+        try {
+            if (!document.getElementById('manage-overrides-style-buttons')) {
+                const style = $el('style', { id: 'manage-overrides-style-buttons', textContent: `
+                    #manage-overrides-modal .model-linker-resolve-btn,
+                    #manage-overrides-modal .comfy-button { font-size: calc(1em - 2px); }
+                `});
+                document.head.appendChild(style);
+            }
+        } catch (e) {}
     }
 
     _header() {
@@ -1745,6 +1780,12 @@ class ManageOverridesDialog extends ComfyDialog {
                     style: { flex: 1, padding: '6px' }
                 }),
                 $el("span", { id: 'ovr-count', textContent: '' })
+            ]),
+            // Header row for two columns
+            $el('div', { style: { display: 'flex', gap: '8px', padding: '6px 8px', borderBottom: '1px solid var(--border-color)', fontWeight: 600, opacity: .9 } }, [
+                $el('div', { style: { flex: '2 1 40%' }, textContent: 'Missing / Category' }),
+                $el('div', { style: { flex: '3 1 55%' }, textContent: 'Override Path' }),
+                $el('div', { style: { flex: '0 0 auto', width: '72px', textAlign: 'right' }, textContent: 'Actions' })
             ]),
             this.listEl = $el("div", { id: 'ovr-list', style: { display: 'flex', flexDirection: 'column', gap: '6px' } })
         ]);
@@ -1817,16 +1858,16 @@ class ManageOverridesDialog extends ComfyDialog {
         const countEl = this.contentEl && this.contentEl.querySelector('#ovr-count');
         if (countEl) countEl.textContent = `${filtered.length}/${mappings.length}`;
         if (!filtered.length) {
-            this.listEl.innerHTML = '<div style="opacity:0.8;">No overrides</div>';
+            this.listEl.innerHTML = '<div style="opacity:0.8; padding:8px;">No overrides</div>';
             return;
         }
         let html = '';
         for (const m of filtered) {
             const delId = `ovr-del-${m.key}`.replace(/[^a-zA-Z0-9_-]/g, '_');
-            html += `<div style="border:1px solid var(--border-color); border-radius:4px; padding:8px; display:flex; gap:8px; align-items:center;">
-                <div style="flex: 2 1 40%; font-weight:600;"><code>${m.original_filename || ''}</code> <span style="opacity:.8;">[${m.category || 'any'}]</span></div>
-                <div style="flex: 3 1 60%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${m.path || ''}">${m.path || ''}</code></div>
-                <div><button id="${delId}" class="model-linker-resolve-btn" style="padding:4px 8px;">Delete</button></div>
+            html += `<div style="border:1px solid var(--border-color); border-radius:4px; padding:6px 8px; display:flex; gap:8px; align-items:center;">
+                <div style="flex: 2 1 40%; font-weight:600; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${m.original_filename || ''}">${m.original_filename || ''}</code> <span style="opacity:.8;">[${m.category || 'any'}]</span></div>
+                <div style="flex: 3 1 55%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${m.path || ''}">${m.path || ''}</code></div>
+                <div style="flex: 0 0 auto; width: 72px; text-align: right;"><button id="${delId}" class="model-linker-resolve-btn" style="padding:4px 8px;">Delete</button></div>
             </div>`;
         }
         this.listEl.innerHTML = html;

--- a/web/linker.js
+++ b/web/linker.js
@@ -1932,6 +1932,73 @@ class LinkerManagerDialog extends ComfyDialog {
     }
 
     /**
+     * Locate a live node that lives inside a subgraph instance's inner graph.
+     *
+     * The root graph (app.graph) only contains top-level nodes and subgraph
+     * *instance* nodes. The nodes defined *inside* a subgraph live in each
+     * instance's own inner graph, reachable via `subgraphNode.subgraph`.
+     * This walks all subgraph instances (recursively, for nested subgraphs)
+     * and returns the matching inner node.
+     *
+     * @param {object} graph    A live LGraph (start with app.graph)
+     * @param {string} subgraphId  Definition UUID of the owning subgraph
+     * @param {number|string} nodeId  Inner node id from the serialized definition
+     * @returns {object|null} The live LGraphNode, or null if not found
+     */
+    findLiveNodeInSubgraphs(graph, subgraphId, nodeId) {
+        const getInner = (n) => {
+            try {
+                if (typeof n.isSubgraphNode === 'function') {
+                    return n.isSubgraphNode() ? (n.subgraph || null) : null;
+                }
+                return n.subgraph || null;
+            } catch (e) {
+                return null;
+            }
+        };
+        const lookup = (sub) => {
+            if (!sub) return null;
+            if (typeof sub.getNodeById === 'function') {
+                const hit = sub.getNodeById(nodeId);
+                if (hit) return hit;
+            }
+            if (sub._nodes_by_id && sub._nodes_by_id[nodeId]) return sub._nodes_by_id[nodeId];
+            return null;
+        };
+
+        // Collect every subgraph instance's inner graph, recursively.
+        const innerGraphs = [];
+        const visit = (g) => {
+            const nodes = (g && (g._nodes || g.nodes)) || [];
+            for (const n of nodes) {
+                const inner = getInner(n);
+                if (inner) {
+                    innerGraphs.push(inner);
+                    visit(inner);
+                }
+            }
+        };
+        visit(graph);
+
+        // First pass: match the owning subgraph by its definition id (most precise).
+        if (subgraphId) {
+            for (const sub of innerGraphs) {
+                if (sub.id === subgraphId) {
+                    const hit = lookup(sub);
+                    if (hit) return hit;
+                }
+            }
+        }
+        // Fallback: id mismatch (older/newer frontends may key differently) —
+        // search every subgraph for a node with this id.
+        for (const sub of innerGraphs) {
+            const hit = lookup(sub);
+            if (hit) return hit;
+        }
+        return null;
+    }
+
+    /**
      * Update workflow in ComfyUI's UI/memory
      * Updates the current workflow in place instead of creating a new tab
      */
@@ -1990,15 +2057,40 @@ class LinkerManagerDialog extends ComfyDialog {
 
                     if (newValue === undefined) continue;
 
-                    // Find the live node in the graph and update its widget value directly
-                    const node = app.graph.getNodeById(nodeId);
+                    // Find the live node in the graph and update its widget value directly.
+                    // Nodes inside a subgraph definition do NOT live in the root graph
+                    // (app.graph) — they live in the subgraph instance's inner graph
+                    // (subgraphNode.subgraph). Route the lookup accordingly so subgraph
+                    // model widgets actually get updated on the live canvas.
+                    let node = null;
+                    if (res.is_top_level === false && res.subgraph_id) {
+                        // Definitely inside a subgraph definition — search subgraphs only.
+                        // (Inner node ids can collide with root ids, so never trust a root match here.)
+                        node = this.findLiveNodeInSubgraphs(app.graph, res.subgraph_id, nodeId);
+                    } else {
+                        node = app.graph.getNodeById(nodeId);
+                        if (!node && res.subgraph_id) {
+                            node = this.findLiveNodeInSubgraphs(app.graph, res.subgraph_id, nodeId);
+                        }
+                    }
                     if (!node) {
-                        console.debug(`Model Linker: Node ${nodeId} not found in live graph (may be inside subgraph definition)`);
+                        console.debug(`Model Linker: Node ${nodeId} not found in live graph (subgraph_id=${res.subgraph_id || 'none'})`);
                         continue;
                     }
 
                     if (node.widgets && node.widgets[widgetIndex]) {
                         const widget = node.widgets[widgetIndex];
+                        const oldValue = widget.value;
+                        // Make sure the resolved value is actually a selectable option,
+                        // otherwise a combo widget keeps treating it as missing.
+                        try {
+                            const plainVal = (res.nested_key && newValue && typeof newValue === 'object')
+                                ? newValue[res.nested_key] : newValue;
+                            const vals = widget.options && widget.options.values;
+                            if (Array.isArray(vals) && typeof plainVal === 'string' && !vals.includes(plainVal)) {
+                                vals.push(plainVal);
+                            }
+                        } catch (_) { /* ignore */ }
                         // For nested dict widgets (e.g. Power Lora Loader), update only the
                         // specific key to preserve other properties (on, strength, etc.)
                         if (res.nested_key && widget.value && typeof widget.value === 'object' && typeof newValue === 'object') {
@@ -2010,6 +2102,14 @@ class LinkerManagerDialog extends ComfyDialog {
                         if (typeof widget.callback === 'function') {
                             try { widget.callback(widget.value); } catch (_) { /* ignore */ }
                         }
+                        // Fire the node's onWidgetChanged hook — this is what ComfyUI's
+                        // error-clearing hooks listen to in order to drop the "missing model"
+                        // flag and remove the red outline. Setting widget.value alone does NOT
+                        // trigger it (that's why users had to toggle the combo manually).
+                        try {
+                            node.onWidgetChanged?.(widget.name, widget.value, oldValue, widget);
+                        } catch (_) { /* ignore */ }
+                        try { node.graph?.incrementVersion?.(); } catch (_) { /* ignore */ }
                         updatedCount++;
                     }
                 }

--- a/web/linker.js
+++ b/web/linker.js
@@ -683,22 +683,28 @@ class LinkerManagerDialog extends ComfyDialog {
     /**
      * Show a model preview image next to an anchor element.
      * Falls back to <video> if <img> fails (for .mp4 previews).
+     * Uses a generation counter to discard stale loads when hovering quickly.
      */
     _showPreview(category, relativePath, anchorEl) {
         if (!category || !relativePath) return;
         const tooltip = this._getPreviewTooltip();
         const url = `/model_linker/preview?type=${encodeURIComponent(category)}&file=${encodeURIComponent(relativePath)}`;
 
+        // Bump generation so earlier async loads are discarded
+        const gen = (this._previewGen = (this._previewGen || 0) + 1);
+
         // Try image first
         const img = document.createElement('img');
         img.src = url;
         img.onload = () => {
+            if (this._previewGen !== gen) return; // stale
             tooltip.innerHTML = '';
             tooltip.appendChild(img);
             this._positionTooltip(tooltip, anchorEl);
             tooltip.style.display = 'block';
         };
         img.onerror = () => {
+            if (this._previewGen !== gen) return; // stale
             // Might be a video preview (.mp4) – try <video>
             const vid = document.createElement('video');
             vid.src = url;
@@ -707,13 +713,14 @@ class LinkerManagerDialog extends ComfyDialog {
             vid.muted = true;
             vid.playsInline = true;
             vid.onloadeddata = () => {
+                if (this._previewGen !== gen) return; // stale
                 tooltip.innerHTML = '';
                 tooltip.appendChild(vid);
                 this._positionTooltip(tooltip, anchorEl);
                 tooltip.style.display = 'block';
             };
             vid.onerror = () => {
-                // No preview available – keep hidden
+                if (this._previewGen !== gen) return; // stale
                 tooltip.style.display = 'none';
             };
         };
@@ -737,8 +744,9 @@ class LinkerManagerDialog extends ComfyDialog {
         tooltip.style.top = top + 'px';
     }
 
-    /** Hide the preview tooltip. */
+    /** Hide the preview tooltip and cancel any in-flight loads. */
     _hidePreview() {
+        this._previewGen = (this._previewGen || 0) + 1; // invalidate pending loads
         if (this._previewTooltip) {
             this._previewTooltip.style.display = 'none';
             this._previewTooltip.innerHTML = '';
@@ -1864,11 +1872,8 @@ class LinkerManagerDialog extends ComfyDialog {
                 this._showPreview(model.category || missing.category, model.relative_path || model.filename, item);
             }
         });
-        listEl.addEventListener('mouseout', (e) => {
-            const item = e.target.closest('[data-idx]');
-            if (item && !item.contains(e.relatedTarget)) {
-                this._hidePreview();
-            }
+        listEl.addEventListener('mouseleave', () => {
+            this._hidePreview();
         });
         document.addEventListener('click', (e) => {
             if (!comboWrap.contains(e.target)) closeList();

--- a/web/linker.js
+++ b/web/linker.js
@@ -1869,6 +1869,7 @@ class ManageOverridesDialog extends ComfyDialog {
                     <div style="flex:1 1 auto; font-weight:600; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${m.original_filename || ''}">${m.original_filename || ''}</code> <span style="opacity:.8;">[${m.category || 'any'}]</span></div>
                     <div style="flex:0 0 auto;"><button id="${delId}" class="model-linker-resolve-btn" style="padding:4px 8px;">Delete</button></div>
                 </div>
+                <div style="height:1px; background: var(--border-color); opacity:.5;"></div>
                 <div style="overflow-wrap:anywhere;"><code title="${m.path || ''}">${m.path || ''}</code></div>
             </div>`;
         }

--- a/web/linker.js
+++ b/web/linker.js
@@ -36,6 +36,9 @@ class LinkerManagerDialog extends ComfyDialog {
         this.allModels = null; // list of all available models for dropdown
         this.pendingResolutions = [];
         this.pendingIndex = new Map(); // key -> index in pendingResolutions
+        this.fullscreen = false;
+        this._dragging = false;
+        this._dragStart = null;
         
         // Create dialog element using $el
         this.element = $el("div.comfy-modal", {
@@ -57,17 +60,58 @@ class LinkerManagerDialog extends ComfyDialog {
                 zIndex: "99999",
                 boxShadow: "0 4px 20px rgba(0,0,0,0.8)",
                 display: "none",
-                flexDirection: "column"
+                flexDirection: "column",
+                resize: "both",
+                overflow: "hidden",
+                minWidth: "640px",
+                minHeight: "420px"
             }
         }, [
             this.createHeader(),
             this.createContent(),
             this.createFooter()
         ]);
+
+        // Apply saved size if present and persist future resizes
+        try {
+            const saved = localStorage.getItem('model_linker_modal_size');
+            if (saved) {
+                const { w, h } = JSON.parse(saved);
+                if (w && h) {
+                    this.element.style.width = `${w}px`;
+                    this.element.style.height = `${h}px`;
+                }
+            }
+            // Restore last position if available
+            const savedPos = localStorage.getItem('model_linker_modal_pos');
+            if (savedPos) {
+                const { top, left } = JSON.parse(savedPos);
+                if (Number.isFinite(top) && Number.isFinite(left)) {
+                    this.element.style.top = `${top}px`;
+                    this.element.style.left = `${left}px`;
+                    this.element.style.transform = 'none';
+                }
+            }
+            // Observe size changes to persist
+            if (window.ResizeObserver) {
+                const ro = new ResizeObserver((entries) => {
+                    for (const entry of entries) {
+                        const rect = entry.target.getBoundingClientRect();
+                        const w = Math.round(rect.width);
+                        const h = Math.round(rect.height);
+                        localStorage.setItem('model_linker_modal_size', JSON.stringify({ w, h }));
+                    }
+                });
+                ro.observe(this.element);
+                this._resizeObserver = ro;
+            }
+        } catch (e) {
+            // ignore storage/observer errors
+        }
     }
     
     createHeader() {
-        return $el("div", {
+        const header = $el("div", {
             style: {
                 display: "flex",
                 justifyContent: "space-between",
@@ -77,47 +121,241 @@ class LinkerManagerDialog extends ComfyDialog {
                 backgroundColor: "var(--comfy-menu-bg, #202020)"
             }
         }, [
-            $el("h2", {
-                textContent: "🔗 Model Linker",
-                style: {
-                    margin: "0",
-                    color: "var(--input-text)",
-                    fontSize: "18px",
-                    fontWeight: "600"
-                }
-            }),
-            $el("button", {
-                textContent: "×",
-                onclick: () => this.close(),
-                style: {
-                    background: "none",
-                    border: "none",
-                    fontSize: "24px",
-                    cursor: "pointer",
-                    color: "var(--input-text)",
-                    padding: "0",
-                    width: "30px",
-                    height: "30px",
-                    borderRadius: "4px",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center"
-                }
-            })
+            $el("div", { style: { display: "flex", gap: "8px", alignItems: "center" } }, [
+                $el("div", {
+                    id: "model-linker-drag-handle",
+                    title: "Drag window",
+                    ondragstart: (e) => e.preventDefault(),
+                    style: {
+                        cursor: "grab",
+                        userSelect: "none",
+                        border: "1px solid var(--border-color)",
+                        borderRadius: "4px",
+                        padding: "0 6px",
+                        height: "24px",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        opacity: "0.9"
+                    }
+                }, [
+                    $el("span", { textContent: "⠿" })
+                ]),
+                $el("h2", {
+                    textContent: "🔗 Model Linker",
+                    style: {
+                        margin: "0",
+                        color: "var(--input-text)",
+                        fontSize: "18px",
+                        fontWeight: "600"
+                    }
+                })
+            ]),
+            $el("div", { style: { display: "flex", gap: "8px", alignItems: "center" } }, [
+                $el("button", {
+                    id: "model-linker-fullscreen-toggle",
+                    title: "Toggle full screen",
+                    textContent: "⛶",
+                    onclick: () => this.toggleFullScreen(),
+                    style: {
+                        background: "none",
+                        border: "1px solid var(--border-color)",
+                        fontSize: "16px",
+                        cursor: "pointer",
+                        color: "var(--input-text)",
+                        padding: "2px 8px",
+                        minWidth: "32px",
+                        height: "30px",
+                        borderRadius: "4px",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center"
+                    }
+                }),
+                $el("button", {
+                    textContent: "×",
+                    onclick: () => this.close(),
+                    style: {
+                        background: "none",
+                        border: "none",
+                        fontSize: "24px",
+                        cursor: "pointer",
+                        color: "var(--input-text)",
+                        padding: "0",
+                        width: "30px",
+                        height: "30px",
+                        borderRadius: "4px",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center"
+                    }
+                })
+            ])
         ]);
+        // Double-click header to toggle full screen
+        header.addEventListener('dblclick', () => this.toggleFullScreen());
+        // Make only the drag handle draggable
+        try {
+            const handle = header.querySelector('#model-linker-drag-handle');
+            if (handle) {
+                const onMouseDown = (e) => {
+                    if (this.fullscreen) return; // no drag in fullscreen
+                    handle.style.cursor = 'grabbing';
+                    this.startDrag(e);
+                };
+                const onMouseUpLocal = () => { handle.style.cursor = 'grab'; };
+                handle.addEventListener('mousedown', onMouseDown);
+                document.addEventListener('mouseup', onMouseUpLocal);
+                this._dragHandleMouseDown = onMouseDown;
+                this._dragHandleMouseUp = onMouseUpLocal;
+            }
+        } catch (e) { /* ignore */ }
+        return header;
     }
     
     createContent() {
+        // Wrap the body in a two-column layout: left = items, right = queued panel
+        const body = $el("div", {
+            id: "model-linker-body",
+            style: {
+                display: "flex",
+                gap: "12px",
+                padding: "16px",
+                flex: "1",
+                minHeight: "0"
+            }
+        });
+
         this.contentElement = $el("div", {
             id: "model-linker-content",
             style: {
-                padding: "16px",
                 overflowY: "auto",
                 flex: "1",
                 minHeight: "0"
             }
         });
-        return this.contentElement;
+
+        this.queueElement = $el("div", {
+            id: "model-linker-queue",
+            style: {
+                width: "320px",
+                minWidth: "280px",
+                maxWidth: "360px",
+                borderLeft: "1px solid var(--border-color)",
+                paddingLeft: "12px",
+                display: "flex",
+                flexDirection: "column"
+            }
+        }, [
+            this.createQueuePanel()
+        ]);
+
+        body.appendChild(this.contentElement);
+        body.appendChild(this.queueElement);
+        return body;
+    }
+
+    createQueuePanel() {
+        // Header row with title and clear button
+        this.queueHeader = $el("div", {
+            style: {
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginBottom: "8px"
+            }
+        }, [
+            $el("div", { id: "queue-title", textContent: "Queued Selections (0)", style: { fontWeight: "600" } }),
+            $el("button", {
+                id: "queue-clear",
+                className: "model-linker-resolve-btn",
+                textContent: "Clear All",
+                onclick: () => this.clearAllQueued(),
+                style: { padding: "4px 8px" }
+            })
+        ]);
+
+        // Scrollable list
+        this.queueList = $el("div", {
+            id: "queue-list",
+            style: {
+                overflowY: "auto",
+                flex: "1",
+                minHeight: "0",
+                border: "1px solid var(--border-color)",
+                borderRadius: "4px",
+                padding: "8px",
+                background: "var(--comfy-input-bg, #2f2f2f)"
+            }
+        });
+
+        const panel = $el("div", { style: { display: "flex", flexDirection: "column", minHeight: "0" } }, [this.queueHeader, this.queueList]);
+        return panel;
+    }
+
+    updateQueuePanel() {
+        if (!this.queueList || !this.queueHeader) return;
+        const list = Array.isArray(this.pendingResolutions) ? this.pendingResolutions : [];
+        // Update title count
+        const title = this.queueHeader.querySelector('#queue-title');
+        if (title) title.textContent = `Queued Selections (${list.length})`;
+
+        if (!list.length) {
+            this.queueList.innerHTML = '<div style="opacity:0.7;">No selections queued.</div>';
+            return;
+        }
+
+        let html = '<div style="display:flex; flex-direction:column; gap:6px;">';
+        for (let i = 0; i < list.length; i++) {
+            const r = list[i];
+            const label = (r.resolved_model?.relative_path || r.resolved_model?.filename || r.resolved_path || '').toString();
+            const nodeLabel = r.node_label || r.node_type || (r.subgraph_id ? 'Subgraph' : 'Node');
+            const orig = (r.original_path || '').toString();
+            const rmId = `queue-remove-${i}`;
+            html += `<div style="border:1px solid var(--border-color); border-radius:4px; padding:6px; background: rgba(255,255,255,0.02);">`;
+            html += `<div style="font-weight:600;">${nodeLabel} #${r.node_id}</div>`;
+            html += `<div style="font-size:12px; opacity:0.9;">Original: <code>${orig}</code></div>`;
+            html += `<div style="font-size:12px;">Selected: <code>${label}</code></div>`;
+            html += `<div style="margin-top:6px;"><button id="${rmId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Remove</button></div>`;
+            html += `</div>`;
+        }
+        html += '</div>';
+        this.queueList.innerHTML = html;
+
+        // Wire remove buttons
+        for (let i = 0; i < list.length; i++) {
+            const rmId = `queue-remove-${i}`;
+            const btn = this.queueList.querySelector(`#${rmId}`);
+            if (btn) {
+                btn.addEventListener('click', () => this.removeQueuedByIndex(i));
+            }
+        }
+    }
+
+    // Remove queued by index (from right panel)
+    removeQueuedByIndex(i) {
+        const list = Array.isArray(this.pendingResolutions) ? this.pendingResolutions : [];
+        if (i < 0 || i >= list.length) return;
+        const r = list[i];
+        // Remove
+        this.pendingResolutions.splice(i, 1);
+        this.rebuildPendingIndex();
+        // Update per-item selected bar
+        const m = { node_id: r.node_id, widget_index: r.widget_index, subgraph_id: r.subgraph_id, is_top_level: r.is_top_level };
+        this.updateSelectedBarForMissing(m);
+        this.updateApplyPendingButton();
+        this.updateQueuePanel();
+    }
+
+    // Clear all queued selections and hide per-item selected bars
+    clearAllQueued() {
+        this.pendingResolutions = [];
+        this.pendingIndex = new Map();
+        this.updateApplyPendingButton();
+        this.updateQueuePanel();
+        try {
+            document.querySelectorAll('.model-linker-selected').forEach(el => { el.style.display = 'none'; el.innerHTML = ''; });
+        } catch (e) { /* ignore */ }
     }
     
     createFooter() {
@@ -162,6 +400,10 @@ class LinkerManagerDialog extends ComfyDialog {
         this.element.style.display = "flex";
         await this.ensureAllModelsLoaded();
         await this.loadWorkflowData();
+        try {
+            const fs = localStorage.getItem('model_linker_modal_fullscreen');
+            if (fs === '1') this.setFullScreen(true);
+        } catch (e) {}
     }
     
     close() {
@@ -201,6 +443,133 @@ class LinkerManagerDialog extends ComfyDialog {
                 callback.apply(this, args);
             }, wait);
         };
+    }
+
+    // Begin window drag
+    startDrag(e) {
+        try {
+            const el = this.element;
+            if (!el) return;
+            const rect = el.getBoundingClientRect();
+            // Switch to absolute top/left (no transform) before dragging
+            el.style.top = `${rect.top}px`;
+            el.style.left = `${rect.left}px`;
+            el.style.transform = 'none';
+            this._dragging = true;
+            this._dragStart = {
+                x: e.clientX,
+                y: e.clientY,
+                top: rect.top,
+                left: rect.left
+            };
+            // Prevent text selection while dragging
+            this._prevUserSelect = document.body.style.userSelect;
+            document.body.style.userSelect = 'none';
+            // Attach listeners
+            this._onMouseMove = (ev) => this.onDrag(ev);
+            this._onMouseUp = () => this.endDrag();
+            document.addEventListener('mousemove', this._onMouseMove);
+            document.addEventListener('mouseup', this._onMouseUp, { once: true });
+        } catch (err) { /* ignore */ }
+    }
+
+    onDrag(e) {
+        if (!this._dragging || !this._dragStart) return;
+        const el = this.element;
+        if (!el) return;
+        const dx = e.clientX - this._dragStart.x;
+        const dy = e.clientY - this._dragStart.y;
+        let top = this._dragStart.top + dy;
+        let left = this._dragStart.left + dx;
+        // Clamp to viewport
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        const w = el.offsetWidth;
+        const h = el.offsetHeight;
+        const pad = 4; // small padding
+        left = Math.max(-w + pad, Math.min(vw - pad, left));
+        top = Math.max(-h + pad, Math.min(vh - pad, top));
+        el.style.top = `${Math.round(top)}px`;
+        el.style.left = `${Math.round(left)}px`;
+    }
+
+    endDrag() {
+        if (!this._dragging) return;
+        this._dragging = false;
+        document.removeEventListener('mousemove', this._onMouseMove);
+        // Persist position
+        try {
+            const el = this.element;
+            const rect = el.getBoundingClientRect();
+            localStorage.setItem('model_linker_modal_pos', JSON.stringify({ top: Math.round(rect.top), left: Math.round(rect.left) }));
+        } catch (e) { /* ignore */ }
+        // Restore selection
+        try { document.body.style.userSelect = this._prevUserSelect || ''; } catch (e) {}
+    }
+
+    // Toggle full screen mode for the dialog
+    toggleFullScreen() {
+        this.setFullScreen(!this.fullscreen);
+    }
+
+    setFullScreen(enable) {
+        this.fullscreen = !!enable;
+        const el = this.element;
+        if (!el) return;
+        const btn = document.getElementById('model-linker-fullscreen-toggle');
+        if (enable) {
+            // Save current size
+            try {
+                const rect = el.getBoundingClientRect();
+                localStorage.setItem('model_linker_modal_size_before_fs', JSON.stringify({ w: Math.round(rect.width), h: Math.round(rect.height) }));
+            } catch (e) {}
+            el.style.top = '0';
+            el.style.left = '0';
+            el.style.transform = 'none';
+            el.style.width = '100vw';
+            el.style.height = '100vh';
+            el.style.maxWidth = '100vw';
+            el.style.maxHeight = '100vh';
+            el.style.borderRadius = '0';
+            el.style.resize = 'none';
+            if (btn) btn.textContent = '🗗';
+            try { localStorage.setItem('model_linker_modal_fullscreen', '1'); } catch (e) {}
+        } else {
+            // Restore centered sizing
+            el.style.maxWidth = '95vw';
+            el.style.maxHeight = '95vh';
+            el.style.borderRadius = '8px';
+            el.style.resize = 'both';
+            // Restore saved pre-FS size if available
+            let wh = null;
+            try { wh = JSON.parse(localStorage.getItem('model_linker_modal_size_before_fs') || 'null'); } catch (e) {}
+            if (wh && wh.w && wh.h) {
+                el.style.width = `${wh.w}px`;
+                el.style.height = `${wh.h}px`;
+            } else {
+                el.style.width = '900px';
+                el.style.height = '700px';
+            }
+            // Restore last known position if available, else center
+            try {
+                const pos = JSON.parse(localStorage.getItem('model_linker_modal_pos') || 'null');
+                if (pos && Number.isFinite(pos.top) && Number.isFinite(pos.left)) {
+                    el.style.top = `${pos.top}px`;
+                    el.style.left = `${pos.left}px`;
+                    el.style.transform = 'none';
+                } else {
+                    el.style.top = '50%';
+                    el.style.left = '50%';
+                    el.style.transform = 'translate(-50%, -50%)';
+                }
+            } catch (e) {
+                el.style.top = '50%';
+                el.style.left = '50%';
+                el.style.transform = 'translate(-50%, -50%)';
+            }
+            if (btn) btn.textContent = '⛶';
+            try { localStorage.setItem('model_linker_modal_fullscreen', '0'); } catch (e) {}
+        }
     }
 
     /**
@@ -409,6 +778,15 @@ class LinkerManagerDialog extends ComfyDialog {
                     }
                 });
             }
+            // Refresh selected UI for this item based on queued selections
+            this.updateSelectedBarForMissing(missing);
+
+            // Wire Locate button (only available for top-level items)
+            const locateId = `locate-${missing.node_id}-${missing.widget_index}`;
+            const locateBtn = container.querySelector(`#${locateId}`);
+            if (locateBtn && missing.is_top_level !== false) {
+                locateBtn.addEventListener('click', () => this.locateNodeInGraph(missing.node_id));
+            }
         });
     }
 
@@ -428,18 +806,43 @@ class LinkerManagerDialog extends ComfyDialog {
         // A node type that's a UUID indicates it's a subgraph instance
         const isSubgraphNode = missing.node_type && missing.node_type.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
         
+        const locateId = `locate-${missing.node_id}-${missing.widget_index}`;
         if (missing.subgraph_name) {
             // Show subgraph name as primary identifier
-            html += `<div style="margin-bottom: 8px;"><strong>Subgraph:</strong> ${missing.subgraph_name} (ID: ${missing.node_id})</div>`;
+            html += `<div style="margin-bottom: 8px; display:flex; align-items:center; justify-content:space-between; gap:8px;">`;
+            html += `<span><strong>Subgraph:</strong> ${missing.subgraph_name} (ID: ${missing.node_id})</span>`;
+            if (missing.is_top_level === false) {
+                html += `<button title="This node is inside a subgraph definition and can't be located in the main canvas" disabled class="model-linker-resolve-btn" style="opacity:.6; padding:2px 8px;">Locate</button>`;
+            } else {
+                html += `<button id="${locateId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Locate</button>`;
+            }
+            html += `</div>`;
         } else if (isSubgraphNode) {
             // Node type is a UUID (subgraph) but we don't have the name (shouldn't happen, but handle gracefully)
-            html += `<div style="margin-bottom: 8px;"><strong>Node:</strong> <em>Subgraph</em> (ID: ${missing.node_id})</div>`;
+            html += `<div style="margin-bottom: 8px; display:flex; align-items:center; justify-content:space-between; gap:8px;">`;
+            html += `<span><strong>Node:</strong> <em>Subgraph</em> (ID: ${missing.node_id})</span>`;
+            if (missing.is_top_level === false) {
+                html += `<button title="This node is inside a subgraph definition and can't be located in the main canvas" disabled class="model-linker-resolve-btn" style="opacity:.6; padding:2px 8px;">Locate</button>`;
+            } else {
+                html += `<button id="${locateId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Locate</button>`;
+            }
+            html += `</div>`;
         } else {
             // Regular node
-            html += `<div style="margin-bottom: 8px;"><strong>Node:</strong> ${missing.node_type} (ID: ${missing.node_id})</div>`;
+            html += `<div style="margin-bottom: 8px; display:flex; align-items:center; justify-content:space-between; gap:8px;">`;
+            html += `<span><strong>Node:</strong> ${missing.node_type} (ID: ${missing.node_id})</span>`;
+            if (missing.is_top_level === false) {
+                html += `<button title="This node is inside a subgraph definition and can't be located in the main canvas" disabled class="model-linker-resolve-btn" style="opacity:.6; padding:2px 8px;">Locate</button>`;
+            } else {
+                html += `<button id="${locateId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Locate</button>`;
+            }
+            html += `</div>`;
         }
         html += `<div style="margin-bottom: 8px;"><strong>Missing Model:</strong> <code>${missing.original_path}</code></div>`;
         html += `<div style="margin-bottom: 8px;"><strong>Category:</strong> ${missing.category || 'unknown'}</div>`;
+        // Selected state placeholder (filled dynamically when user queues a selection)
+        const selectedId = `selected-${missing.node_id}-${missing.widget_index}-${missing.subgraph_id || 'top'}`;
+        html += `<div id="${selectedId}" class="model-linker-selected" style="display:none; margin: 8px 0; padding: 8px; border: 1px solid var(--border-color, #444); border-radius: 4px; background: rgba(10,169,110,0.08);"></div>`;
 
         if (hasMatches) {
             // Filter out matches below 70% confidence threshold
@@ -645,6 +1048,65 @@ class LinkerManagerDialog extends ComfyDialog {
         }, dismissTime);
     }
 
+    // Build a stable key for a missing entry (same as queueResolution)
+    getResolutionKey(missing) {
+        return `${missing.node_id}:${missing.widget_index}:${missing.subgraph_id || ''}:${missing.is_top_level ? 'T' : 'F'}`;
+    }
+
+    // Return queued resolution (if any) for a missing entry
+    getQueuedResolutionForMissing(missing) {
+        const key = this.getResolutionKey(missing);
+        if (this.pendingIndex.has(key)) {
+            const idx = this.pendingIndex.get(key);
+            return this.pendingResolutions[idx];
+        }
+        return null;
+    }
+
+    // Rebuild index mapping after removals
+    rebuildPendingIndex() {
+        this.pendingIndex = new Map();
+        for (let i = 0; i < this.pendingResolutions.length; i++) {
+            const r = this.pendingResolutions[i];
+            const k = `${r.node_id}:${r.widget_index}:${r.subgraph_id || ''}:${r.is_top_level ? 'T' : 'F'}`;
+            this.pendingIndex.set(k, i);
+        }
+    }
+
+    // Remove a queued resolution for a missing item
+    removeQueuedResolution(missing) {
+        const key = this.getResolutionKey(missing);
+        if (!this.pendingIndex.has(key)) return;
+        const idx = this.pendingIndex.get(key);
+        this.pendingResolutions.splice(idx, 1);
+        this.rebuildPendingIndex();
+        this.updateSelectedBarForMissing(missing);
+        this.updateApplyPendingButton();
+        this.updateQueuePanel();
+    }
+
+    // Update the per-item selected UI area
+    updateSelectedBarForMissing(missing) {
+        const containerId = `selected-${missing.node_id}-${missing.widget_index}-${missing.subgraph_id || 'top'}`;
+        const el = document.getElementById(containerId);
+        if (!el) return;
+        const queued = this.getQueuedResolutionForMissing(missing);
+        if (!queued) {
+            el.style.display = 'none';
+            el.innerHTML = '';
+            return;
+        }
+        const model = queued.resolved_model || {};
+        const label = model.relative_path || model.filename || queued.resolved_path || 'selected model';
+        const removeId = `selected-remove-${missing.node_id}-${missing.widget_index}-${missing.subgraph_id || 'top'}`;
+        el.innerHTML = `<strong>Selected:</strong> <code>${label}</code> <button id="${removeId}" class="model-linker-resolve-btn" style="margin-left:8px; padding: 2px 8px;">Remove</button>`;
+        el.style.display = '';
+        const btn = document.getElementById(removeId);
+        if (btn) {
+            btn.onclick = () => this.removeQueuedResolution(missing);
+        }
+    }
+
     /**
      * Queue a single resolution (do not call backend yet)
      */
@@ -662,7 +1124,9 @@ class LinkerManagerDialog extends ComfyDialog {
             resolved_model: resolvedModel,
             original_path: missing.original_path,
             subgraph_id: missing.subgraph_id,
-            is_top_level: missing.is_top_level
+            is_top_level: missing.is_top_level,
+            node_type: missing.node_type,
+            node_label: missing.subgraph_name || missing.node_type
         };
 
         const key = `${resolution.node_id}:${resolution.widget_index}:${resolution.subgraph_id || ''}:${resolution.is_top_level ? 'T' : 'F'}`;
@@ -675,19 +1139,9 @@ class LinkerManagerDialog extends ComfyDialog {
             this.pendingResolutions.push(resolution);
         }
 
-        // Mark block as queued
-        try {
-            const blockId = `missing-${missing.node_id}-${missing.widget_index}`;
-            const block = document.getElementById(blockId);
-            if (block && !block.querySelector('.queued-badge')) {
-                const badge = document.createElement('div');
-                badge.className = 'queued-badge';
-                badge.style.cssText = 'margin-top:8px;color:#0aa96e;font-weight:600;';
-                badge.textContent = 'Queued for linking';
-                block.appendChild(badge);
-            }
-        } catch (e) { /* ignore DOM errors */ }
-
+        // Update selected bar UI
+        this.updateSelectedBarForMissing(missing);
+        this.updateQueuePanel();
         this.updateApplyPendingButton();
     }
 
@@ -815,6 +1269,7 @@ class LinkerManagerDialog extends ComfyDialog {
                 this.pendingResolutions = [];
                 this.pendingIndex = new Map();
                 this.updateApplyPendingButton();
+                this.updateQueuePanel();
                 await this.loadWorkflowData(data.workflow);
             } else {
                 this.showNotification('Failed to apply selections: ' + (data.error || 'Unknown error'), 'error');
@@ -831,6 +1286,50 @@ class LinkerManagerDialog extends ComfyDialog {
         this.applyPendingBtn.textContent = `Apply Selected (${n})`;
         this.applyPendingBtn.disabled = n === 0;
         this.applyPendingBtn.style.opacity = n === 0 ? '0.6' : '1';
+        // Keep the queue panel count in sync
+        this.updateQueuePanel();
+    }
+
+    // Center and select a node in the current graph by ID
+    locateNodeInGraph(nodeId) {
+        try {
+            if (!app || !app.graph) {
+                this.showNotification('Graph not available', 'error');
+                return;
+            }
+            let node = null;
+            if (typeof app.graph.getNodeById === 'function') {
+                try { node = app.graph.getNodeById(nodeId); } catch(e) { /* ignore */ }
+            }
+            if (!node && app.graph._nodes_by_id) {
+                node = app.graph._nodes_by_id[nodeId];
+            }
+            if (!node) {
+                this.showNotification('Node not found in current view', 'error');
+                return;
+            }
+            const canvas = app.canvas;
+            if (canvas) {
+                // Deselect other nodes
+                if (typeof canvas.deselectAllNodes === 'function') {
+                    try { canvas.deselectAllNodes(); } catch(e) {}
+                }
+                // Select this node
+                if (typeof canvas.selectNode === 'function') {
+                    try { canvas.selectNode(node, true); } catch(e) {}
+                } else if (typeof canvas.selectNodes === 'function') {
+                    try { canvas.selectNodes([node], true); } catch(e) {}
+                }
+                // Center on node
+                if (typeof canvas.centerOnNode === 'function') {
+                    try { canvas.centerOnNode(node); } catch(e) {}
+                } else if (typeof canvas.scrollToCenter === 'function') {
+                    try { canvas.scrollToCenter(); } catch(e) {}
+                }
+            }
+        } catch (error) {
+            console.error('Model Linker: locateNodeInGraph error', error);
+        }
     }
 
     /**

--- a/web/linker.js
+++ b/web/linker.js
@@ -1871,7 +1871,7 @@ class ManageOverridesDialog extends ComfyDialog {
                 </div>
                 <div style="height:1px; background: var(--border-color); opacity:.5;"></div>
                 <div style="display:flex; align-items:center; justify-content:space-between; gap:8px;">
-                    <div style="flex:1 1 auto; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${(m.path || '').split(/\\\\|\//).pop() || ''}">${(m.path || '').split(/\\\\|\//).pop() || ''}</code></div>
+                    <div style="flex:1 1 auto; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"><code title="${(m.path || '').split(/[\\/]/).pop() || ''}">${(m.path || '').split(/[\\/]/).pop() || ''}</code></div>
                     <div style="flex:0 0 auto;"><button id="ovr-pathbtn-${(m.key || '').replace(/[^a-zA-Z0-9_-]/g, '_')}" class="model-linker-resolve-btn" style="padding:4px 8px;">Path</button></div>
                 </div>
                 <div id="ovr-pathrow-${(m.key || '').replace(/[^a-zA-Z0-9_-]/g, '_')}" style="display:none; overflow-wrap:anywhere; opacity:.9;"><code title="${m.path || ''}">${m.path || ''}</code></div>

--- a/web/linker.js
+++ b/web/linker.js
@@ -6,9 +6,9 @@
 
 // Import ComfyUI APIs
 // These paths are relative to the ComfyUI web directory
-import { app } from "../../../scripts/app.js";
-import { api } from "../../../scripts/api.js";
-import { $el, ComfyDialog } from "../../../scripts/ui.js";
+import { app } from "../../scripts/app.js";
+import { api } from "../../scripts/api.js";
+import { $el, ComfyDialog } from "../../scripts/ui.js";
 
 // Check if ComfyButtonGroup is available (from newer ComfyUI versions)
 let ComfyButtonGroup = null;
@@ -39,7 +39,7 @@ class LinkerManagerDialog extends ComfyDialog {
         this.fullscreen = false;
         this._dragging = false;
         this._dragStart = null;
-        
+
         // Create dialog element using $el
         this.element = $el("div.comfy-modal", {
             id: "model-linker-modal",
@@ -198,7 +198,7 @@ class LinkerManagerDialog extends ComfyDialog {
             // ignore storage/observer errors
         }
     }
-    
+
     createHeader() {
         const header = $el("div", {
             style: {
@@ -320,7 +320,7 @@ class LinkerManagerDialog extends ComfyDialog {
         } catch (e) { /* ignore */ }
         return header;
     }
-    
+
     createContent() {
         // Wrap the body in a two-column layout: left = items, right = queued panel
         const body = $el("div", {
@@ -388,13 +388,13 @@ class LinkerManagerDialog extends ComfyDialog {
                     this.queueElement.style.width = `${w}px`;
                 }
             }
-        } catch (e) {}
+        } catch (e) { }
 
         try {
             const onSplitMouseDown = (e) => this.startSplitDrag(e);
             this.splitterElement.addEventListener('mousedown', onSplitMouseDown);
             this._splitterMouseDown = onSplitMouseDown;
-        } catch (e) {}
+        } catch (e) { }
         // Toggle icon always visible
         try {
             this.queueToggleIcon = $el("button", {
@@ -417,12 +417,12 @@ class LinkerManagerDialog extends ComfyDialog {
             }, [document.createTextNode('⮜')]);
             body.appendChild(this.queueToggleIcon);
             this.updateQueueToggleIcon();
-        } catch (e) {}
+        } catch (e) { }
         // Restore queue collapsed state
         try {
             const col = localStorage.getItem('model_linker_queue_collapsed');
             if (col === '1') this.setQueueCollapsed(true);
-        } catch (e) {}
+        } catch (e) { }
         return body;
     }
 
@@ -508,7 +508,7 @@ class LinkerManagerDialog extends ComfyDialog {
             html += `<div style="font-size:12px; opacity:0.9;">Original: <code>${orig}</code></div>`;
             html += `<div style="font-size:12px;">Selected: <code>${label}</code></div>`;
             html += `<div style="margin-top:6px;"><button id="${rmId}" class="model-linker-resolve-btn" style="padding:2px 8px;">Remove</button></div>`;
-            
+
         }
         html += '</div>';
         this.queueList.innerHTML = html;
@@ -560,11 +560,11 @@ class LinkerManagerDialog extends ComfyDialog {
         if (this.queueCollapsed) {
             this.queueElement.style.display = 'none';
             this.splitterElement.style.display = 'none';
-            try { localStorage.setItem('model_linker_queue_collapsed', '1'); } catch (e) {}
+            try { localStorage.setItem('model_linker_queue_collapsed', '1'); } catch (e) { }
         } else {
             this.queueElement.style.display = '';
             this.splitterElement.style.display = '';
-            try { localStorage.setItem('model_linker_queue_collapsed', '0'); } catch (e) {}
+            try { localStorage.setItem('model_linker_queue_collapsed', '0'); } catch (e) { }
         }
         this.updateQueuePanel();
         this.updateQueueToggleIcon();
@@ -581,7 +581,7 @@ class LinkerManagerDialog extends ComfyDialog {
             this.queueToggleIcon.title = 'Collapse queue';
         }
     }
-    
+
     createFooter() {
         // Create buttons container
         const footer = $el("div", {
@@ -619,7 +619,7 @@ class LinkerManagerDialog extends ComfyDialog {
         footer.appendChild(autoBtn);
         return footer;
     }
-    
+
     async show() {
         this.element.style.display = "flex";
         await this.ensureAllModelsLoaded();
@@ -627,9 +627,9 @@ class LinkerManagerDialog extends ComfyDialog {
         try {
             const fs = localStorage.getItem('model_linker_modal_fullscreen');
             if (fs === '1') this.setFullScreen(true);
-        } catch (e) {}
+        } catch (e) { }
     }
-    
+
     close() {
         this.element.style.display = "none";
     }
@@ -728,7 +728,7 @@ class LinkerManagerDialog extends ComfyDialog {
             localStorage.setItem('model_linker_modal_pos', JSON.stringify({ top: Math.round(rect.top), left: Math.round(rect.left) }));
         } catch (e) { /* ignore */ }
         // Restore selection
-        try { document.body.style.userSelect = this._prevUserSelect || ''; } catch (e) {}
+        try { document.body.style.userSelect = this._prevUserSelect || ''; } catch (e) { }
     }
 
     // Begin split drag for resizable panels
@@ -772,8 +772,8 @@ class LinkerManagerDialog extends ComfyDialog {
         try {
             const rect = this.queueElement.getBoundingClientRect();
             localStorage.setItem('model_linker_split_w', String(Math.round(rect.width)));
-        } catch (e) {}
-        try { document.body.style.userSelect = this._prevUserSelect || ''; } catch (e) {}
+        } catch (e) { }
+        try { document.body.style.userSelect = this._prevUserSelect || ''; } catch (e) { }
     }
 
     // Toggle full screen mode for the dialog
@@ -791,7 +791,7 @@ class LinkerManagerDialog extends ComfyDialog {
             try {
                 const rect = el.getBoundingClientRect();
                 localStorage.setItem('model_linker_modal_size_before_fs', JSON.stringify({ w: Math.round(rect.width), h: Math.round(rect.height) }));
-            } catch (e) {}
+            } catch (e) { }
             el.style.top = '0';
             el.style.left = '0';
             el.style.transform = 'none';
@@ -802,7 +802,7 @@ class LinkerManagerDialog extends ComfyDialog {
             el.style.borderRadius = '0';
             el.style.resize = 'none';
             if (btn) btn.textContent = '🗗';
-            try { localStorage.setItem('model_linker_modal_fullscreen', '1'); } catch (e) {}
+            try { localStorage.setItem('model_linker_modal_fullscreen', '1'); } catch (e) { }
         } else {
             // Restore centered sizing
             el.style.maxWidth = '95vw';
@@ -811,7 +811,7 @@ class LinkerManagerDialog extends ComfyDialog {
             el.style.resize = 'both';
             // Restore saved pre-FS size if available
             let wh = null;
-            try { wh = JSON.parse(localStorage.getItem('model_linker_modal_size_before_fs') || 'null'); } catch (e) {}
+            try { wh = JSON.parse(localStorage.getItem('model_linker_modal_size_before_fs') || 'null'); } catch (e) { }
             if (wh && wh.w && wh.h) {
                 el.style.width = `${wh.w}px`;
                 el.style.height = `${wh.h}px`;
@@ -837,7 +837,7 @@ class LinkerManagerDialog extends ComfyDialog {
                 el.style.transform = 'translate(-50%, -50%)';
             }
             if (btn) btn.textContent = '⛶';
-            try { localStorage.setItem('model_linker_modal_fullscreen', '0'); } catch (e) {}
+            try { localStorage.setItem('model_linker_modal_fullscreen', '0'); } catch (e) { }
         }
     }
 
@@ -855,7 +855,7 @@ class LinkerManagerDialog extends ComfyDialog {
             if (!workflow) {
                 workflow = this.getCurrentWorkflow();
             }
-            
+
             if (!workflow) {
                 this.contentElement.innerHTML = '<p>No workflow loaded. Please load a workflow first.</p>';
                 return;
@@ -919,23 +919,23 @@ class LinkerManagerDialog extends ComfyDialog {
         const sortedMissingModels = missingModels.sort((a, b) => {
             const aMatches = a.matches || [];
             const bMatches = b.matches || [];
-            
+
             // Filter to 70%+ confidence
             const aFiltered = aMatches.filter(m => m.confidence >= 70);
             const bFiltered = bMatches.filter(m => m.confidence >= 70);
-            
+
             // Check if they have 100% matches
             const aHas100 = aFiltered.some(m => m.confidence === 100);
             const bHas100 = bFiltered.some(m => m.confidence === 100);
-            
+
             // If one has 100% and the other doesn't, prioritize the one with 100%
             if (aHas100 && !bHas100) return -1;
             if (!aHas100 && bHas100) return 1;
-            
+
             // If both have 100% or neither has 100%, sort by best confidence
             const aBestConf = aFiltered.length > 0 ? Math.max(...aFiltered.map(m => m.confidence)) : 0;
             const bBestConf = bFiltered.length > 0 ? Math.max(...bFiltered.map(m => m.confidence)) : 0;
-            
+
             return bBestConf - aBestConf; // Higher confidence first
         });
 
@@ -950,14 +950,14 @@ class LinkerManagerDialog extends ComfyDialog {
         // Note: We need to match the exact same logic as renderMissingModel to find which buttons were rendered
         sortedMissingModels.forEach((missing, missingIndex) => {
             const allMatches = missing.matches || [];
-            
+
             // Filter out matches below 70% confidence threshold
             const filteredMatches = allMatches.filter(m => m.confidence >= 70);
-            
+
             // Filter to only 100% matches if available, otherwise use filtered matches (>=70%)
             const perfectMatches = filteredMatches.filter(m => m.confidence === 100);
             const otherMatches = filteredMatches.filter(m => m.confidence < 100 && m.confidence >= 70);
-            
+
             // Match the same logic as renderMissingModel
             const savedMatches = filteredMatches.filter(m => m.is_override);
             let matchesToShow = null;
@@ -977,14 +977,14 @@ class LinkerManagerDialog extends ComfyDialog {
                     if (!matchesToShow.some(x => x.model?.path === p)) matchesToShow.push(sm);
                 }
             }
-            
+
             // Sort: 100% matches first, then by confidence descending (same as renderMissingModel)
             const sortedMatches = matchesToShow.sort((a, b) => {
                 if (a.confidence === 100 && b.confidence !== 100) return -1;
                 if (a.confidence !== 100 && b.confidence === 100) return 1;
                 return b.confidence - a.confidence;
             });
-            
+
             // Attach listener for all displayed matches so the user can pick explicitly
             sortedMatches.forEach((match, matchIndex) => {
                 const buttonId = `resolve-${missing.node_id}-${missing.widget_index}-${matchIndex}`;
@@ -1017,17 +1017,17 @@ class LinkerManagerDialog extends ComfyDialog {
      */
     renderMissingModel(missing) {
         const allMatches = missing.matches || [];
-        
+
         // Filter out matches below 70% confidence threshold
         const filteredMatches = allMatches.filter(m => m.confidence >= 70);
         const hasMatches = filteredMatches.length > 0;
 
         let html = `<div id="missing-${missing.node_id}-${missing.widget_index}" style="border: 1px solid var(--border-color, #444); padding: 12px; border-radius: 4px; display:flex; flex-direction:column; align-items:stretch; gap:8px; white-space: normal;">`;
-        
+
         // Display subgraph name as primary identifier if available, otherwise show node type
         // A node type that's a UUID indicates it's a subgraph instance
         const isSubgraphNode = missing.node_type && missing.node_type.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
-        
+
         const locateId = `locate-${missing.node_id}-${missing.widget_index}`;
         if (missing.subgraph_name) {
             // Show subgraph name as primary identifier
@@ -1069,11 +1069,11 @@ class LinkerManagerDialog extends ComfyDialog {
         if (hasMatches) {
             // Filter out matches below 70% confidence threshold
             const filteredMatches = allMatches.filter(m => m.confidence >= 70);
-            
+
             // Separate 100% matches from others (from filtered list)
             const perfectMatches = filteredMatches.filter(m => m.confidence === 100);
             const otherMatches = filteredMatches.filter(m => m.confidence < 100 && m.confidence >= 70);
-            
+
             // If we have 100% matches, show them AND always include saved matches as well.
             const savedMatches = filteredMatches.filter(m => m.is_override);
             let matchesToShow = null;
@@ -1091,20 +1091,20 @@ class LinkerManagerDialog extends ComfyDialog {
                     if (!matchesToShow.some(x => x.model?.path === p)) matchesToShow.push(sm);
                 }
             }
-            
+
             html += `<div style="margin-top: 12px;"><strong>Suggested Matches:</strong></div>`;
             html += '<ul style="margin: 8px 0; padding-left: 20px;">';
-            
+
             // Sort: 100% matches first, then by confidence descending
             const sortedMatches = matchesToShow.sort((a, b) => {
                 if (a.confidence === 100 && b.confidence !== 100) return -1;
                 if (a.confidence !== 100 && b.confidence === 100) return 1;
                 return b.confidence - a.confidence;
             });
-            
+
             // Find the highest confidence match (even if not 100%)
             const highestConfidenceMatch = sortedMatches.length > 0 ? sortedMatches[0] : null;
-            
+
             for (let matchIndex = 0; matchIndex < sortedMatches.length; matchIndex++) {
                 const match = sortedMatches[matchIndex];
                 const buttonId = `resolve-${missing.node_id}-${missing.widget_index}-${matchIndex}`;
@@ -1123,9 +1123,9 @@ class LinkerManagerDialog extends ComfyDialog {
                     </button>`;
                 html += `</li>`;
             }
-            
+
             html += '</ul>';
-            
+
             // Add note if only showing 100% matches
             if (perfectMatches.length > 0 && otherMatches.length > 0) {
                 html += `<div style="color: #888; font-size: 12px; margin-top: 8px; font-style: italic;">Showing only 100% confidence matches. ${otherMatches.length} other match${otherMatches.length > 1 ? 'es' : ''} available.</div>`;
@@ -1140,16 +1140,16 @@ class LinkerManagerDialog extends ComfyDialog {
         // Compact summary removed (duplicate of info shown above)
 
         // combo picker injected via attachModelCombo
-        
-        
-        
-        
-        
-        
-        
-        
+
+
+
+
+
+
+
+
         html += `</div>`;
-        
+
         html += `</div>`;
 
         html += '</div>';
@@ -1398,7 +1398,7 @@ class LinkerManagerDialog extends ComfyDialog {
             for (const missing of missingModels) {
                 const matches = missing.matches || [];
                 const perfectMatch = matches.find((m) => m.confidence === 100);
-                
+
                 if (perfectMatch && perfectMatch.model) {
                     resolutions.push({
                         node_id: missing.node_id,
@@ -1433,17 +1433,17 @@ class LinkerManagerDialog extends ComfyDialog {
             }
 
             const resolveData = await resolveResponse.json();
-            
+
             if (resolveData.success) {
                 // Update workflow in ComfyUI
                 await this.updateWorkflowInComfyUI(resolveData.workflow);
-                
+
                 // Show success notification
                 this.showNotification(
                     `✓ Successfully linked ${resolutions.length} model${resolutions.length > 1 ? 's' : ''}!`,
                     'success'
                 );
-                
+
                 // Reload dialog using the updated workflow from API response
                 // This ensures we're analyzing the correct updated workflow
                 await this.loadWorkflowData(resolveData.workflow);
@@ -1485,7 +1485,7 @@ class LinkerManagerDialog extends ComfyDialog {
             const data = await response.json();
             if (data.success) {
                 await this.updateWorkflowInComfyUI(data.workflow);
-                this.showNotification(`✓ Linked ${list.length} selection${list.length>1?'s':''}`, 'success');
+                this.showNotification(`✓ Linked ${list.length} selection${list.length > 1 ? 's' : ''}`, 'success');
                 // Clear queue and refresh analysis
                 this.pendingResolutions = [];
                 this.pendingIndex = new Map();
@@ -1548,7 +1548,7 @@ class LinkerManagerDialog extends ComfyDialog {
                 listEl.innerHTML = '<div style="padding:6px; opacity:0.8;">No results</div>';
                 return;
             }
-            const esc = (s) => (s || '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+            const esc = (s) => (s || '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', '\'': '&#39;' }[c]));
             const q = (query || '').toLowerCase();
             let html = '';
             for (let i = 0; i < items.length; i++) {
@@ -1561,10 +1561,10 @@ class LinkerManagerDialog extends ComfyDialog {
                     const low = labRaw.toLowerCase();
                     let out = '';
                     let idx = 0;
-                    for (;;) {
+                    for (; ;) {
                         const j = low.indexOf(q, idx);
                         if (j === -1) { out += esc(labRaw.slice(idx)); break; }
-                        out += esc(labRaw.slice(idx, j)) + `<span style="font-weight:600; text-decoration:underline;">${esc(labRaw.slice(j, j+q.length))}</span>`;
+                        out += esc(labRaw.slice(idx, j)) + `<span style="font-weight:600; text-decoration:underline;">${esc(labRaw.slice(j, j + q.length))}</span>`;
                         idx = j + q.length;
                     }
                     labelHtml = out;
@@ -1625,7 +1625,7 @@ class LinkerManagerDialog extends ComfyDialog {
                 // Prevent wrapping in labels when measuring
                 try {
                     listEl.querySelectorAll('code').forEach(c => c.style.whiteSpace = 'nowrap');
-                } catch (e) {}
+                } catch (e) { }
                 let contentW = Math.ceil(listEl.scrollWidth);
                 const viewportRight = window.innerWidth - 16;
                 const maxAllowed = Math.max(200, viewportRight - inputRect.left);
@@ -1638,7 +1638,7 @@ class LinkerManagerDialog extends ComfyDialog {
                     listEl.style.visibility = prevVis || '';
                     listEl.style.width = prevWidth;
                 }
-            } catch (_) {}
+            } catch (_) { }
         };
         const openList = () => { updateListPosition(); listEl.style.display = 'block'; };
         const closeList = () => { listEl.style.display = 'none'; activeIndex = -1; };
@@ -1716,7 +1716,7 @@ class LinkerManagerDialog extends ComfyDialog {
                 try {
                     const resp = await api.fetchApi('/model_linker/models');
                     if (resp.ok) this.allModels = await resp.json();
-                } catch (e) {}
+                } catch (e) { }
                 updateList(); openList();
             });
         }
@@ -1731,7 +1731,7 @@ class LinkerManagerDialog extends ComfyDialog {
             }
             let node = null;
             if (typeof app.graph.getNodeById === 'function') {
-                try { node = app.graph.getNodeById(nodeId); } catch(e) { /* ignore */ }
+                try { node = app.graph.getNodeById(nodeId); } catch (e) { /* ignore */ }
             }
             if (!node && app.graph._nodes_by_id) {
                 node = app.graph._nodes_by_id[nodeId];
@@ -1744,19 +1744,19 @@ class LinkerManagerDialog extends ComfyDialog {
             if (canvas) {
                 // Deselect other nodes
                 if (typeof canvas.deselectAllNodes === 'function') {
-                    try { canvas.deselectAllNodes(); } catch(e) {}
+                    try { canvas.deselectAllNodes(); } catch (e) { }
                 }
                 // Select this node
                 if (typeof canvas.selectNode === 'function') {
-                    try { canvas.selectNode(node, true); } catch(e) {}
+                    try { canvas.selectNode(node, true); } catch (e) { }
                 } else if (typeof canvas.selectNodes === 'function') {
-                    try { canvas.selectNodes([node], true); } catch(e) {}
+                    try { canvas.selectNodes([node], true); } catch (e) { }
                 }
                 // Center on node
                 if (typeof canvas.centerOnNode === 'function') {
-                    try { canvas.centerOnNode(node); } catch(e) {}
+                    try { canvas.centerOnNode(node); } catch (e) { }
                 } else if (typeof canvas.scrollToCenter === 'function') {
-                    try { canvas.scrollToCenter(); } catch(e) {}
+                    try { canvas.scrollToCenter(); } catch (e) { }
                 }
             }
         } catch (error) {
@@ -1862,18 +1862,19 @@ class ManageOverridesDialog extends ComfyDialog {
                 ro.observe(this.element);
                 this._ro = ro;
             }
-        } catch (e) {}
+        } catch (e) { }
 
         // Scoped smaller button font-size (2px less) in overrides modal
         try {
             if (!document.getElementById('manage-overrides-style-buttons')) {
-                const style = $el('style', { id: 'manage-overrides-style-buttons', textContent: `
+                const style = $el('style', {
+                    id: 'manage-overrides-style-buttons', textContent: `
                     #manage-overrides-modal .model-linker-resolve-btn,
                     #manage-overrides-modal .comfy-button { font-size: calc(1em - 2px); }
                 `});
                 document.head.appendChild(style);
             }
-        } catch (e) {}
+        } catch (e) { }
     }
 
     _header() {
@@ -2242,5 +2243,29 @@ const modelLinker = new ModelLinker();
 // Register the extension
 app.registerExtension({
     name: "Model Linker",
-    setup: modelLinker.setup
+    setup: modelLinker.setup,
+    // Support for new ComfyUI Frontend menu system
+    commands: [
+        {
+            id: "model-linker-open",
+            icon: "🔗",
+            label: "Model Linker",
+            function: () => modelLinker.openLinkerManager()
+        }
+    ],
+    menuCommands: [
+        {
+            path: ["View"],
+            commands: ["model-linker-open"]
+        }
+    ],
+    // Add to canvas right-click menu
+    getCanvasMenuItems() {
+        return [
+            {
+                content: "🔗 Model Linker",
+                callback: () => modelLinker.openLinkerManager()
+            }
+        ];
+    }
 });

--- a/web/linker.js
+++ b/web/linker.js
@@ -1447,18 +1447,35 @@ class LinkerManagerDialog extends ComfyDialog {
         const savedPaths = new Set((missing.matches || []).filter(m => m.is_override && m.model && m.model.path).map(m => m.model.path));
         const getPool = () => Array.isArray(this.allModels) ? this.allModels : [];
 
-        const renderList = (items) => {
+        const renderList = (items, query, activeIdx) => {
             if (!items || !items.length) {
                 listEl.innerHTML = '<div style="padding:6px; opacity:0.8;">No results</div>';
                 return;
             }
+            const esc = (s) => (s || '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+            const q = (query || '').toLowerCase();
             let html = '';
             for (let i = 0; i < items.length; i++) {
                 const m = items[i];
-                const label = m.relative_path || m.filename || '';
+                const labRaw = m.relative_path || m.filename || '';
                 const isSaved = savedPaths.has(m.path);
-                html += `<div data-idx="${i}" style="padding:6px; display:flex; align-items:center; gap:6px; cursor:pointer;">
-                    <code style="flex:1;">${label}</code>
+                // highlight simple substring matches
+                let labelHtml = esc(labRaw);
+                if (q) {
+                    const low = labRaw.toLowerCase();
+                    let out = '';
+                    let idx = 0;
+                    for (;;) {
+                        const j = low.indexOf(q, idx);
+                        if (j === -1) { out += esc(labRaw.slice(idx)); break; }
+                        out += esc(labRaw.slice(idx, j)) + `<span style="font-weight:600; text-decoration:underline;">${esc(labRaw.slice(j, j+q.length))}</span>`;
+                        idx = j + q.length;
+                    }
+                    labelHtml = out;
+                }
+                const activeStyle = (i === activeIdx) ? 'background: rgba(0,122,204,0.25);' : '';
+                html += `<div data-idx="${i}" style="${activeStyle} padding:6px; display:flex; align-items:center; gap:6px; cursor:pointer;">
+                    <code style="flex:1;">${labelHtml}</code>
                     ${isSaved ? '<span style="color:#0aa96e; font-weight:600;">(saved)</span>' : ''}
                 </div>`;
             }
@@ -1482,28 +1499,58 @@ class LinkerManagerDialog extends ComfyDialog {
             return items.slice(0, 100).map(x => x.m);
         };
 
+        let currentItems = [];
+        let activeIndex = -1;
         const openList = () => { listEl.style.display = 'block'; };
-        const closeList = () => { listEl.style.display = 'none'; };
+        const closeList = () => { listEl.style.display = 'none'; activeIndex = -1; };
         const isOpen = () => listEl.style.display !== 'none';
 
         const updateList = () => {
             const q = inputEl.value || '';
-            const items = buildSuggestions(q);
-            renderList(items);
+            currentItems = buildSuggestions(q);
+            if (currentItems.length && activeIndex < 0) activeIndex = 0;
+            if (!currentItems.length) activeIndex = -1;
+            renderList(currentItems, q, activeIndex);
         };
 
         inputEl.addEventListener('focus', () => { openList(); updateList(); });
         inputEl.addEventListener('input', this.debounce(() => { updateList(); openList(); }, 120));
         inputEl.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') { closeList(); return; }
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                if (!isOpen()) { openList(); updateList(); return; }
+                if (!currentItems.length) return;
+                activeIndex = Math.min(currentItems.length - 1, (activeIndex < 0 ? 0 : activeIndex + 1));
+                renderList(currentItems, inputEl.value || '', activeIndex);
+                return;
+            }
+            if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                if (!isOpen()) { openList(); updateList(); return; }
+                if (!currentItems.length) return;
+                activeIndex = Math.max(0, (activeIndex < 0 ? 0 : activeIndex - 1));
+                renderList(currentItems, inputEl.value || '', activeIndex);
+                return;
+            }
+            if (e.key === 'Enter') {
+                if (!isOpen()) return;
+                if (activeIndex >= 0 && activeIndex < currentItems.length) {
+                    const chosen = currentItems[activeIndex];
+                    if (chosen) {
+                        this.queueResolution(missing, chosen);
+                        inputEl.value = chosen.relative_path || chosen.filename || '';
+                        closeList();
+                    }
+                }
+                return;
+            }
         });
         listEl.addEventListener('mousedown', (e) => {
             const item = e.target.closest('[data-idx]');
             if (!item) return;
             const idx = parseInt(item.getAttribute('data-idx'), 10);
-            const q = inputEl.value || '';
-            const items = buildSuggestions(q);
-            const chosen = items[idx];
+            const chosen = currentItems[idx];
             if (chosen) {
                 this.queueResolution(missing, chosen);
                 inputEl.value = chosen.relative_path || chosen.filename || '';


### PR DESCRIPTION
## Summary
- **Fix canvas wipe bug**: `graph.configure()` was clearing the entire graph and rebuilding from scratch, which fails silently on newer ComfyUI frontends — leaving an empty canvas with all nodes gone
- **Targeted widget updates**: Replaced full-graph replacement with direct widget value updates via `getNodeById()`, only touching the specific model widgets that were resolved
- **Widget callback support**: Triggers widget callbacks after update so combo dropdowns and other UI elements reflect the new values

## Test plan
- [ ] Load a workflow with missing models
- [ ] Open Model Linker and apply resolutions (both auto-resolve and manual select)
- [ ] Verify all nodes remain on the canvas after applying
- [ ] Verify resolved model values appear correctly in the updated nodes
- [ ] Test with workflows containing subgraph nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)