### PR TITLE
Feat: hf native downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,33 @@ A ComfyUI extension that relinks missing models in shared workflows: it finds th
 4. Link individual matches, use **Auto-Link** for all 100% matches, or **Download All Missing** for models with known sources
 5. Save your workflow when ready
 
+## HuggingFace authentication
+
+Downloads from HuggingFace are **anonymous by default** — a token is only ever sent if a model turns out to be gated (license click-through required) and one is available, or if you explicitly opt in. Model Linker never reads your `hf auth login` session (the cached token file the HuggingFace CLI stores in your home folder); a long-running shell login shouldn't silently leak into a download you didn't expect it to touch.
+
+**If a download fails with "this model is gated"**, set a token in the environment ComfyUI itself runs in (not just your shell — see below), then retry. If nothing's configured there, that's the only case a gated download can't complete on its own.
+
+**"Always send HF token" checkbox** (in the Missing Models dialog's footer): off by default. Turning it on sends your token on every HuggingFace download from the start instead of only when a model is actually gated. Not required for correctness — anonymous downloads work fine for public models — but authenticated requests can get better treatment from HuggingFace's CDN under load, so it's worth enabling if you're pulling a lot of models on a fast connection and want to avoid anonymous rate limits. The checkbox shows **(detected)** in green or **(not detected)** in red next to it, so you can tell at a glance whether a token is actually available to send before you bother checking it.
+
+### Providing a token
+
+Set either of these in the environment ComfyUI's process runs in (an env var exported in your shell before launching it won't reach ComfyUI unless ComfyUI itself was started from that same shell — see your launch script):
+
+- `HF_TOKEN` (preferred)
+- `HUGGING_FACE_HUB_TOKEN` (older name, kept for compatibility with other tools)
+
+For example, added to whatever script launches ComfyUI:
+```bat
+:: Windows batch
+set "HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+```bash
+# Linux/macOS shell
+export HF_TOKEN="hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+Don't have a token yet? Generate one at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) — a **Read**-scoped token is sufficient, no write access needed. You'll also need to visit the gated model's page on HuggingFace at least once and accept its license terms before a token grants access to it.
+
 ## License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -32,13 +32,11 @@ A ComfyUI extension that relinks missing models in shared workflows: it finds th
 
 ## HuggingFace authentication
 
-Downloads from HuggingFace are **anonymous by default** — a token is only ever sent if a model turns out to be gated (license click-through required) and one is available, or if you explicitly opt in. Model Linker never reads your `hf auth login` session (the cached token file the HuggingFace CLI stores in your home folder); a long-running shell login shouldn't silently leak into a download you didn't expect it to touch.
+Downloads from HuggingFace are **anonymous by default** — a token is only ever sent if a model turns out to be gated (license click-through required) and one is available, or if you explicitly opt in. 
 
-**If a download fails with "this model is gated"**, set a token in the environment ComfyUI itself runs in (not just your shell — see below), then retry. If nothing's configured there, that's the only case a gated download can't complete on its own.
+**"Always send HF token" checkbox**: off by default. Turning it on sends your token on every HuggingFace download from the start instead of only when a model is actually gated. Not required for correctness — anonymous downloads work fine for public models — but authenticated requests can be more resilient to throttling under load, so it's potentially worth enabling if you're pulling a lot of models on a fast connection and want to avoid anonymous rate limits. The checkbox shows **(detected)** in green or **(not detected)** in red next to it, so you can tell at a glance whether a token is actually available to send before you bother checking it.
 
-**"Always send HF token" checkbox** (in the Missing Models dialog's footer): off by default. Turning it on sends your token on every HuggingFace download from the start instead of only when a model is actually gated. Not required for correctness — anonymous downloads work fine for public models — but authenticated requests can get better treatment from HuggingFace's CDN under load, so it's worth enabling if you're pulling a lot of models on a fast connection and want to avoid anonymous rate limits. The checkbox shows **(detected)** in green or **(not detected)** in red next to it, so you can tell at a glance whether a token is actually available to send before you bother checking it.
-
-### Providing a token
+### Providing a HF_TOKEN
 
 Set either of these in the environment ComfyUI's process runs in (an env var exported in your shell before launching it won't reach ComfyUI unless ComfyUI itself was started from that same shell — see your launch script):
 

--- a/__init__.py
+++ b/__init__.py
@@ -432,6 +432,19 @@ class ModelLinkerExtension:
                             status=500
                         )
                 
+                @routes.get("/model_linker/hf_token_status")
+                async def hf_token_status(request):
+                    """Whether HF_TOKEN / HUGGING_FACE_HUB_TOKEN is set in the
+                    environment ComfyUI is running in -- never the token value
+                    itself, just whether the "Always send HF token" checkbox
+                    would actually have something to send."""
+                    try:
+                        from .core.hf_downloader import _resolve_env_token
+                        return web.json_response({'detected': _resolve_env_token() is not None})
+                    except Exception as e:
+                        self.logger.error(f"Model Linker hf_token_status error: {e}", exc_info=True)
+                        return web.json_response({'detected': False, 'error': str(e)}, status=500)
+
                 @routes.post("/model_linker/cancel/{download_id}")
                 async def cancel_download_route(request):
                     """Cancel a download in progress."""

--- a/__init__.py
+++ b/__init__.py
@@ -361,24 +361,27 @@ class ModelLinkerExtension:
                                 status=400
                             )
                         
-                        # Build headers if needed
+                        # Build headers if needed. HuggingFace URLs are routed to the
+                        # huggingface_hub-backed engine by start_background_download,
+                        # which resolves its own auth (env var, escalating only on a
+                        # gated/401/403 response) -- send_hf_token is the "always send"
+                        # opt-in checkbox, off by default. CivitAI keeps the legacy
+                        # token-in-URL scheme untouched.
                         headers = {}
-                        if 'huggingface.co' in url:
-                            hf_token = data.get('hf_token', '')
-                            if hf_token:
-                                headers['Authorization'] = f'Bearer {hf_token}'
-                        elif 'civitai.com' in url:
+                        send_hf_token = bool(data.get('send_hf_token', False))
+                        if 'civitai.com' in url:
                             civitai_key = data.get('civitai_key', '')
                             if civitai_key and 'token=' not in url:
                                 url += f"{'&' if '?' in url else '?'}token={civitai_key}"
-                        
+
                         # Start background download
                         download_id = start_background_download(
                             url=url,
                             filename=filename,
                             category=category,
                             headers=headers if headers else None,
-                            subfolder=subfolder
+                            subfolder=subfolder,
+                            send_hf_token=send_hf_token
                         )
                         
                         return web.json_response({

--- a/core/_hf_worker.py
+++ b/core/_hf_worker.py
@@ -1,0 +1,140 @@
+"""
+Standalone worker for downloading a single file from HuggingFace via
+huggingface_hub.
+
+This file is deliberately NOT imported by the rest of this package -- it is
+launched with `sys.executable <this file>` as its own OS process (see
+hf_downloader.py). That's on purpose: ComfyUI loads custom node packages
+through a dynamic importlib trick keyed on the node's absolute install path
+(see nodes.py's load_custom_node / get_module_name, which does
+`sys_module_name = module_path.replace(".", "_x_")` and injects the result
+straight into sys.modules). That name isn't a real, path-discoverable
+package, so a freshly spawned interpreter has no way to `import` anything
+from this package by module name -- which rules out Python's own
+`multiprocessing` (it pickles a reference to the target function and expects
+the child to re-import its defining module). Running this file directly by
+path sidesteps the problem entirely: it's executed as a normal __main__
+script, using only huggingface_hub and the stdlib, and talks to the parent
+over stdin/stdout instead.
+
+Protocol:
+  stdin:  one JSON object, one line:
+          {"repo_id": ..., "filename": ..., "revision": ...,
+           "local_dir": ..., "token": <str|false>, "fallback_token": <str|null>}
+  stdout: newline-delimited JSON events as the download progresses:
+          {"event": "progress", "n": <int>, "total": <int>}
+          {"event": "retrying"}
+          {"event": "done", "path": <str>}
+          {"event": "error", "message": <str>}
+"""
+
+import sys
+import json
+import time
+
+
+def emit(event, **fields):
+    sys.stdout.write(json.dumps({"event": event, **fields}) + "\n")
+    sys.stdout.flush()
+
+
+class _ProgressTqdm:
+    """Minimal tqdm-compatible shim. hf_hub_download only ever calls
+    update()/close() on the instances it creates and reads .total/.n --
+    it doesn't need the real rendering machinery, just this surface."""
+
+    def __init__(self, *args, **kwargs):
+        self.total = kwargs.get("total") or 0
+        self.n = 0
+        self._last_emit = 0.0
+
+    def update(self, n=1):
+        self.n += n
+        now = time.monotonic()
+        # Throttle -- an active 1GB/s+ transfer would otherwise flood the
+        # pipe with a JSON line per chunk.
+        if now - self._last_emit >= 0.2:
+            self._last_emit = now
+            emit("progress", n=self.n, total=self.total)
+
+    def close(self):
+        emit("progress", n=self.n, total=self.total)
+
+    def set_description(self, *args, **kwargs):
+        pass
+
+    def refresh(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def main():
+    line = sys.stdin.readline()
+    request = json.loads(line)
+
+    repo_id = request["repo_id"]
+    filename = request["filename"]
+    revision = request.get("revision") or "main"
+    local_dir = request["local_dir"]
+    token = request.get("token", False)
+    fallback_token = request.get("fallback_token")
+
+    try:
+        import huggingface_hub
+        from huggingface_hub.errors import HfHubHTTPError
+    except Exception as e:
+        emit("error", message=f"huggingface_hub is not available in this environment: {e}")
+        return
+
+    def attempt(use_token):
+        return huggingface_hub.hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            revision=revision,
+            local_dir=local_dir,
+            token=use_token,
+            tqdm_class=_ProgressTqdm,
+        )
+
+    try:
+        try:
+            path = attempt(token)
+        except HfHubHTTPError as e:
+            status = getattr(e.response, "status_code", None)
+            # Only escalate when the first attempt was deliberately
+            # anonymous (token is False, not just falsy) -- if the caller
+            # already sent a token and it was refused, there's nothing
+            # left to fall back to.
+            if status in (401, 403) and token is False and fallback_token:
+                emit("retrying")
+                path = attempt(fallback_token)
+            else:
+                raise
+        emit("done", path=path)
+        return
+    except HfHubHTTPError as e:
+        status = getattr(e.response, "status_code", None)
+        if status in (401, 403):
+            if fallback_token:
+                message = f"Unauthorized (HTTP {status}): the HuggingFace token was rejected."
+            else:
+                message = (
+                    f"Unauthorized (HTTP {status}): this model is gated. Set HF_TOKEN or "
+                    "HUGGING_FACE_HUB_TOKEN in the environment ComfyUI runs in and retry."
+                )
+        elif status == 404:
+            message = "Model not found (HTTP 404): the file may have been moved or deleted."
+        else:
+            message = str(e)
+        emit("error", message=message)
+    except Exception as e:
+        emit("error", message=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/core/_hf_worker.py
+++ b/core/_hf_worker.py
@@ -14,34 +14,72 @@ from this package by module name -- which rules out Python's own
 `multiprocessing` (it pickles a reference to the target function and expects
 the child to re-import its defining module). Running this file directly by
 path sidesteps the problem entirely: it's executed as a normal __main__
-script, using only huggingface_hub and the stdlib, and talks to the parent
-over stdin/stdout instead.
+script, using only huggingface_hub/hf_xet and the stdlib, and talks to the
+parent over stdin/stdout instead.
+
+Why this doesn't just call hf_hub_download() and read its tqdm_class hook
+(the first version of this file did): confirmed empirically (see project
+history) that hf_hub_download's built-in Xet integration wraps hf_xet's
+*deprecated* download_files() call, whose progress callback just doesn't
+fire incrementally during the transfer for at least some file sizes -- 0%,
+then one jump to completion. hf_xet's newer XetSession/XetFileDownloadGroup
+API exposes a `group.progress()` method that can be *polled* on our own
+schedule instead of depending on how often the native code calls back into
+Python, which tested as actually responsive. So: files hosted on Xet storage
+go through that path directly; anything else (still on classic Git-LFS-over-
+HTTP, or if the Xet path raises for any reason) falls back to the plain
+hf_hub_download() call, which already has smooth progress on its own since
+that's a normal sequential HTTP stream.
 
 Protocol:
   stdin:  one JSON object, one line:
           {"repo_id": ..., "filename": ..., "revision": ...,
            "local_dir": ..., "token": <str|false>, "fallback_token": <str|null>}
-  stdout: newline-delimited JSON events as the download progresses:
+  stdout: newline-delimited JSON events, each carrying "t" (time.time()):
           {"event": "progress", "n": <int>, "total": <int>}
           {"event": "retrying"}
           {"event": "done", "path": <str>}
           {"event": "error", "message": <str>}
+          {"event": "log", "message": <str>, ...extra diagnostic fields}
+          The "log" event is verbose diagnostic detail (elapsed times, byte
+          counts, which code path was taken, poll counts) -- not needed for
+          normal operation, but means a real run's console output is enough
+          to reconstruct exactly what happened without re-instrumenting.
 """
 
+import os
 import sys
 import json
 import time
+import threading
 
 
 def emit(event, **fields):
-    sys.stdout.write(json.dumps({"event": event, **fields}) + "\n")
+    sys.stdout.write(json.dumps({"event": event, "t": time.time(), **fields}) + "\n")
     sys.stdout.flush()
 
 
+def log(message, **fields):
+    emit("log", message=message, **fields)
+
+
+def _gated_message(status, fallback_token):
+    if status in (401, 403):
+        if fallback_token:
+            return f"Unauthorized (HTTP {status}): the HuggingFace token was rejected."
+        return (
+            f"Unauthorized (HTTP {status}): this model is gated. Set HF_TOKEN or "
+            "HUGGING_FACE_HUB_TOKEN in the environment ComfyUI runs in and retry."
+        )
+    if status == 404:
+        return "Model not found (HTTP 404): the file may have been moved or deleted."
+    return None
+
+
 class _ProgressTqdm:
-    """Minimal tqdm-compatible shim. hf_hub_download only ever calls
-    update()/close() on the instances it creates and reads .total/.n --
-    it doesn't need the real rendering machinery, just this surface."""
+    """Minimal tqdm-compatible shim for the hf_hub_download fallback path.
+    It only ever calls update()/close() on the instances it creates and
+    reads .total/.n -- it doesn't need the real rendering machinery."""
 
     def __init__(self, *args, **kwargs):
         self.total = kwargs.get("total") or 0
@@ -51,8 +89,6 @@ class _ProgressTqdm:
     def update(self, n=1):
         self.n += n
         now = time.monotonic()
-        # Throttle -- an active 1GB/s+ transfer would otherwise flood the
-        # pipe with a JSON line per chunk.
         if now - self._last_emit >= 0.2:
             self._last_emit = now
             emit("progress", n=self.n, total=self.total)
@@ -73,9 +109,103 @@ class _ProgressTqdm:
         self.close()
 
 
+def _download_via_xet(metadata, token, local_dir, filename):
+    """Download a Xet-hosted file with real, pollable progress. Writes
+    directly to an explicit flat path under local_dir -- unlike
+    hf_hub_download's local_dir mode, start_download_file() takes whatever
+    destination path we hand it, so there's no repo-structure replication
+    to flatten afterward for this path."""
+    import hf_xet
+    from huggingface_hub.utils import build_hf_headers
+    from huggingface_hub.utils._xet import refresh_xet_connection_info
+
+    headers = build_hf_headers(token=token)
+
+    t0 = time.time()
+    conn = refresh_xet_connection_info(file_data=metadata.xet_file_data, headers=headers)
+    log("xet connection info refreshed", elapsed=round(time.time() - t0, 3), endpoint=conn.endpoint)
+
+    session = hf_xet.XetSession()
+    group = session.new_file_download_group(
+        endpoint=conn.endpoint,
+        token=conn.access_token,
+        token_expiry_unix_secs=conn.expiration_unix_epoch,
+        token_refresh_url=metadata.xet_file_data.refresh_route,
+        token_refresh_headers=headers,
+    )
+
+    os.makedirs(local_dir, exist_ok=True)
+    dest_path = os.path.join(local_dir, filename.split("/")[-1])
+    file_info = hf_xet.XetFileInfo(hash=metadata.xet_file_data.file_hash, file_size=metadata.size)
+
+    t_start = time.time()
+    group.start_download_file(file_info, dest_path)
+    log("xet download started", dest_path=dest_path, total=metadata.size)
+
+    result = {}
+
+    def waiter():
+        result["report"] = group.wait_to_finish()
+
+    wait_thread = threading.Thread(target=waiter, daemon=True)
+    wait_thread.start()
+
+    last_completed = -1
+    poll_count = 0
+    while wait_thread.is_alive():
+        p = group.progress()
+        poll_count += 1
+        if p.total_bytes_completed != last_completed:
+            last_completed = p.total_bytes_completed
+            total = p.total_bytes or metadata.size
+            emit("progress", n=p.total_bytes_completed, total=total)
+            log(
+                "xet progress tick",
+                elapsed=round(time.time() - t_start, 2),
+                completed=p.total_bytes_completed,
+                total=p.total_bytes,
+                rate_bytes_per_sec=p.total_bytes_completion_rate,
+                poll_count=poll_count,
+            )
+        time.sleep(0.3)
+
+    wait_thread.join(timeout=10)
+    log(
+        "xet download finished",
+        elapsed=round(time.time() - t_start, 2),
+        poll_count=poll_count,
+        report=str(result.get("report")),
+    )
+
+    if not os.path.exists(dest_path):
+        raise RuntimeError("xet download reported completion but the destination file is missing")
+
+    emit("progress", n=metadata.size, total=metadata.size)
+    emit("done", path=dest_path)
+
+
+def _download_via_hf_hub_download(repo_id, filename, revision, local_dir, token):
+    """Classic path: hf_hub_download's normal sequential-HTTP download,
+    which already has smooth progress on its own via the tqdm_class hook.
+    Used for anything not on Xet storage, and as a fallback if the Xet path
+    above raises for any reason."""
+    import huggingface_hub
+
+    t0 = time.time()
+    path = huggingface_hub.hf_hub_download(
+        repo_id=repo_id,
+        filename=filename,
+        revision=revision,
+        local_dir=local_dir,
+        token=token,
+        tqdm_class=_ProgressTqdm,
+    )
+    log("hf_hub_download path finished", elapsed=round(time.time() - t0, 2))
+    emit("done", path=path)
+
+
 def main():
-    line = sys.stdin.readline()
-    request = json.loads(line)
+    request = json.loads(sys.stdin.readline())
 
     repo_id = request["repo_id"]
     filename = request["filename"]
@@ -85,53 +215,55 @@ def main():
     fallback_token = request.get("fallback_token")
 
     try:
-        import huggingface_hub
+        from huggingface_hub import hf_hub_url, get_hf_file_metadata
         from huggingface_hub.errors import HfHubHTTPError
     except Exception as e:
         emit("error", message=f"huggingface_hub is not available in this environment: {e}")
         return
 
-    def attempt(use_token):
-        return huggingface_hub.hf_hub_download(
-            repo_id=repo_id,
-            filename=filename,
-            revision=revision,
-            local_dir=local_dir,
-            token=use_token,
-            tqdm_class=_ProgressTqdm,
-        )
-
+    # Resolve metadata first -- this is also our one auth checkpoint: if it
+    # succeeds (anonymously or otherwise), the same token is reused for
+    # whichever download path we take below, since HF enforces gating
+    # consistently across the metadata and file endpoints.
+    url = hf_hub_url(repo_id, filename, revision=revision)
+    log("resolving metadata", url=url, token_mode=("string" if isinstance(token, str) else token))
+    t0 = time.time()
     try:
         try:
-            path = attempt(token)
+            metadata = get_hf_file_metadata(url, token=token)
         except HfHubHTTPError as e:
             status = getattr(e.response, "status_code", None)
-            # Only escalate when the first attempt was deliberately
-            # anonymous (token is False, not just falsy) -- if the caller
-            # already sent a token and it was refused, there's nothing
-            # left to fall back to.
             if status in (401, 403) and token is False and fallback_token:
                 emit("retrying")
-                path = attempt(fallback_token)
+                token = fallback_token
+                metadata = get_hf_file_metadata(url, token=token)
             else:
                 raise
-        emit("done", path=path)
-        return
     except HfHubHTTPError as e:
         status = getattr(e.response, "status_code", None)
-        if status in (401, 403):
-            if fallback_token:
-                message = f"Unauthorized (HTTP {status}): the HuggingFace token was rejected."
-            else:
-                message = (
-                    f"Unauthorized (HTTP {status}): this model is gated. Set HF_TOKEN or "
-                    "HUGGING_FACE_HUB_TOKEN in the environment ComfyUI runs in and retry."
-                )
-        elif status == 404:
-            message = "Model not found (HTTP 404): the file may have been moved or deleted."
-        else:
-            message = str(e)
-        emit("error", message=message)
+        emit("error", message=_gated_message(status, fallback_token) or str(e))
+        return
+    except Exception as e:
+        emit("error", message=str(e))
+        return
+
+    log(
+        "metadata resolved",
+        elapsed=round(time.time() - t0, 3),
+        size=metadata.size,
+        xet=metadata.xet_file_data is not None,
+        etag=metadata.etag,
+    )
+
+    if metadata.xet_file_data is not None:
+        try:
+            _download_via_xet(metadata, token, local_dir, filename)
+            return
+        except Exception as e:
+            log("xet path raised, falling back to hf_hub_download", error=str(e))
+
+    try:
+        _download_via_hf_hub_download(repo_id, filename, revision, local_dir, token)
     except Exception as e:
         emit("error", message=str(e))
 

--- a/core/_hf_worker.py
+++ b/core/_hf_worker.py
@@ -14,22 +14,29 @@ from this package by module name -- which rules out Python's own
 `multiprocessing` (it pickles a reference to the target function and expects
 the child to re-import its defining module). Running this file directly by
 path sidesteps the problem entirely: it's executed as a normal __main__
-script, using only huggingface_hub/hf_xet and the stdlib, and talks to the
-parent over stdin/stdout instead.
+script, using only huggingface_hub and the stdlib, and talks to the parent
+over stdin/stdout instead.
 
-Why this doesn't just call hf_hub_download() and read its tqdm_class hook
-(the first version of this file did): confirmed empirically (see project
-history) that hf_hub_download's built-in Xet integration wraps hf_xet's
-*deprecated* download_files() call, whose progress callback just doesn't
-fire incrementally during the transfer for at least some file sizes -- 0%,
-then one jump to completion. hf_xet's newer XetSession/XetFileDownloadGroup
-API exposes a `group.progress()` method that can be *polled* on our own
-schedule instead of depending on how often the native code calls back into
-Python, which tested as actually responsive. So: files hosted on Xet storage
-go through that path directly; anything else (still on classic Git-LFS-over-
-HTTP, or if the Xet path raises for any reason) falls back to the plain
-hf_hub_download() call, which already has smooth progress on its own since
-that's a normal sequential HTTP stream.
+Progress design (see project history for the full trail -- this went
+through several dead ends before landing here): earlier versions of this
+file hand-rolled a direct hf_xet XetSession/XetFileDownloadGroup integration
+to get real incremental progress, reaching into huggingface_hub's *private*
+utils._xet module. That broke the first time it hit a different
+huggingface_hub version in the wild (refresh_xet_connection_info doesn't
+exist in 1.26.0 -- the internals were rewritten). Turns out that rewrite
+also fixed the underlying problem at the source: huggingface_hub's Xet
+integration now drives a *dual* progress bar (network transfer bytes,
+updated continuously, vs. file-reconstruction bytes, which lags behind since
+it's only counted once chunks are verified and flushed to disk) and will
+call `update_transfer(n)` / `set_transfer_postfix_str(...)` on a supplied
+tqdm_class *if that class defines them* -- confirmed empirically to fire
+~10x/second with real incremental byte counts. So: no more private-API
+reimplementation needed. Plain hf_hub_download(..., tqdm_class=...) is
+enough, as long as the tqdm shim implements that (undocumented but stable
+enough in practice) dual-method contract. On older huggingface_hub versions
+that don't know about update_transfer, it's simply never called and this
+falls back to whatever granularity the reconstruction-only update() gets --
+today's existing behavior, not a regression.
 
 Protocol:
   stdin:  one JSON object, one line:
@@ -41,17 +48,11 @@ Protocol:
           {"event": "done", "path": <str>}
           {"event": "error", "message": <str>}
           {"event": "log", "message": <str>, ...extra diagnostic fields}
-          The "log" event is verbose diagnostic detail (elapsed times, byte
-          counts, which code path was taken, poll counts) -- not needed for
-          normal operation, but means a real run's console output is enough
-          to reconstruct exactly what happened without re-instrumenting.
 """
 
-import os
 import sys
 import json
 import time
-import threading
 
 
 def emit(event, **fields):
@@ -61,6 +62,61 @@ def emit(event, **fields):
 
 def log(message, **fields):
     emit("log", message=message, **fields)
+
+
+class _ProgressTqdm:
+    """tqdm-compatible shim for hf_hub_download's tqdm_class hook.
+
+    Implements both the standard surface (update()/close(), driven by the
+    "reconstruction" bar -- bytes verified and flushed to disk, which for
+    Xet-accelerated downloads can lag well behind the network) and the
+    update_transfer()/set_transfer_postfix_str() pair huggingface_hub's
+    dual-bar Xet progress reporter calls for actual network bytes received.
+    Both report increments toward the *same* eventual total, not two
+    different things to sum -- tracked separately and reported as whichever
+    is further along, so this never double-counts and never regresses if a
+    given huggingface_hub version only calls one of the two.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.total = kwargs.get("total") or 0
+        self._reconstruction_n = 0
+        self._transfer_n = 0
+        self.n = 0
+        self._last_emit = 0.0
+
+    def _report(self, force=False):
+        self.n = max(self._reconstruction_n, self._transfer_n)
+        now = time.monotonic()
+        if force or now - self._last_emit >= 0.2:
+            self._last_emit = now
+            emit("progress", n=self.n, total=self.total)
+
+    def update(self, n=1):
+        self._reconstruction_n += n
+        self._report()
+
+    def update_transfer(self, n=1):
+        self._transfer_n += n
+        self._report()
+
+    def set_transfer_postfix_str(self, *args, **kwargs):
+        pass
+
+    def close(self):
+        self._report(force=True)
+
+    def set_description(self, *args, **kwargs):
+        pass
+
+    def refresh(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
 
 
 def _gated_message(status, fallback_token):
@@ -76,134 +132,6 @@ def _gated_message(status, fallback_token):
     return None
 
 
-class _ProgressTqdm:
-    """Minimal tqdm-compatible shim for the hf_hub_download fallback path.
-    It only ever calls update()/close() on the instances it creates and
-    reads .total/.n -- it doesn't need the real rendering machinery."""
-
-    def __init__(self, *args, **kwargs):
-        self.total = kwargs.get("total") or 0
-        self.n = 0
-        self._last_emit = 0.0
-
-    def update(self, n=1):
-        self.n += n
-        now = time.monotonic()
-        if now - self._last_emit >= 0.2:
-            self._last_emit = now
-            emit("progress", n=self.n, total=self.total)
-
-    def close(self):
-        emit("progress", n=self.n, total=self.total)
-
-    def set_description(self, *args, **kwargs):
-        pass
-
-    def refresh(self, *args, **kwargs):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self.close()
-
-
-def _download_via_xet(metadata, token, local_dir, filename):
-    """Download a Xet-hosted file with real, pollable progress. Writes
-    directly to an explicit flat path under local_dir -- unlike
-    hf_hub_download's local_dir mode, start_download_file() takes whatever
-    destination path we hand it, so there's no repo-structure replication
-    to flatten afterward for this path."""
-    import hf_xet
-    from huggingface_hub.utils import build_hf_headers
-    from huggingface_hub.utils._xet import refresh_xet_connection_info
-
-    headers = build_hf_headers(token=token)
-
-    t0 = time.time()
-    conn = refresh_xet_connection_info(file_data=metadata.xet_file_data, headers=headers)
-    log("xet connection info refreshed", elapsed=round(time.time() - t0, 3), endpoint=conn.endpoint)
-
-    session = hf_xet.XetSession()
-    group = session.new_file_download_group(
-        endpoint=conn.endpoint,
-        token=conn.access_token,
-        token_expiry_unix_secs=conn.expiration_unix_epoch,
-        token_refresh_url=metadata.xet_file_data.refresh_route,
-        token_refresh_headers=headers,
-    )
-
-    os.makedirs(local_dir, exist_ok=True)
-    dest_path = os.path.join(local_dir, filename.split("/")[-1])
-    file_info = hf_xet.XetFileInfo(hash=metadata.xet_file_data.file_hash, file_size=metadata.size)
-
-    t_start = time.time()
-    group.start_download_file(file_info, dest_path)
-    log("xet download started", dest_path=dest_path, total=metadata.size)
-
-    result = {}
-
-    def waiter():
-        result["report"] = group.wait_to_finish()
-
-    wait_thread = threading.Thread(target=waiter, daemon=True)
-    wait_thread.start()
-
-    last_completed = -1
-    poll_count = 0
-    while wait_thread.is_alive():
-        p = group.progress()
-        poll_count += 1
-        if p.total_bytes_completed != last_completed:
-            last_completed = p.total_bytes_completed
-            total = p.total_bytes or metadata.size
-            emit("progress", n=p.total_bytes_completed, total=total)
-            log(
-                "xet progress tick",
-                elapsed=round(time.time() - t_start, 2),
-                completed=p.total_bytes_completed,
-                total=p.total_bytes,
-                rate_bytes_per_sec=p.total_bytes_completion_rate,
-                poll_count=poll_count,
-            )
-        time.sleep(0.3)
-
-    wait_thread.join(timeout=10)
-    log(
-        "xet download finished",
-        elapsed=round(time.time() - t_start, 2),
-        poll_count=poll_count,
-        report=str(result.get("report")),
-    )
-
-    if not os.path.exists(dest_path):
-        raise RuntimeError("xet download reported completion but the destination file is missing")
-
-    emit("progress", n=metadata.size, total=metadata.size)
-    emit("done", path=dest_path)
-
-
-def _download_via_hf_hub_download(repo_id, filename, revision, local_dir, token):
-    """Classic path: hf_hub_download's normal sequential-HTTP download,
-    which already has smooth progress on its own via the tqdm_class hook.
-    Used for anything not on Xet storage, and as a fallback if the Xet path
-    above raises for any reason."""
-    import huggingface_hub
-
-    t0 = time.time()
-    path = huggingface_hub.hf_hub_download(
-        repo_id=repo_id,
-        filename=filename,
-        revision=revision,
-        local_dir=local_dir,
-        token=token,
-        tqdm_class=_ProgressTqdm,
-    )
-    log("hf_hub_download path finished", elapsed=round(time.time() - t0, 2))
-    emit("done", path=path)
-
-
 def main():
     request = json.loads(sys.stdin.readline())
 
@@ -215,55 +143,42 @@ def main():
     fallback_token = request.get("fallback_token")
 
     try:
-        from huggingface_hub import hf_hub_url, get_hf_file_metadata
+        import huggingface_hub
         from huggingface_hub.errors import HfHubHTTPError
     except Exception as e:
         emit("error", message=f"huggingface_hub is not available in this environment: {e}")
         return
 
-    # Resolve metadata first -- this is also our one auth checkpoint: if it
-    # succeeds (anonymously or otherwise), the same token is reused for
-    # whichever download path we take below, since HF enforces gating
-    # consistently across the metadata and file endpoints.
-    url = hf_hub_url(repo_id, filename, revision=revision)
-    log("resolving metadata", url=url, token_mode=("string" if isinstance(token, str) else token))
+    def attempt(use_token):
+        return huggingface_hub.hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            revision=revision,
+            local_dir=local_dir,
+            token=use_token,
+            tqdm_class=_ProgressTqdm,
+        )
+
     t0 = time.time()
     try:
         try:
-            metadata = get_hf_file_metadata(url, token=token)
+            path = attempt(token)
         except HfHubHTTPError as e:
             status = getattr(e.response, "status_code", None)
+            # Only escalate when the first attempt was deliberately
+            # anonymous (token is False, not just falsy) -- if the caller
+            # already sent a token and it was refused, there's nothing
+            # left to fall back to.
             if status in (401, 403) and token is False and fallback_token:
                 emit("retrying")
-                token = fallback_token
-                metadata = get_hf_file_metadata(url, token=token)
+                path = attempt(fallback_token)
             else:
                 raise
+        log("download finished", elapsed=round(time.time() - t0, 2))
+        emit("done", path=path)
     except HfHubHTTPError as e:
         status = getattr(e.response, "status_code", None)
         emit("error", message=_gated_message(status, fallback_token) or str(e))
-        return
-    except Exception as e:
-        emit("error", message=str(e))
-        return
-
-    log(
-        "metadata resolved",
-        elapsed=round(time.time() - t0, 3),
-        size=metadata.size,
-        xet=metadata.xet_file_data is not None,
-        etag=metadata.etag,
-    )
-
-    if metadata.xet_file_data is not None:
-        try:
-            _download_via_xet(metadata, token, local_dir, filename)
-            return
-        except Exception as e:
-            log("xet path raised, falling back to hf_hub_download", error=str(e))
-
-    try:
-        _download_via_hf_hub_download(repo_id, filename, revision, local_dir, token)
     except Exception as e:
         emit("error", message=str(e))
 

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -428,20 +428,49 @@ def start_background_download(
     filename: str,
     category: str,
     headers: Optional[Dict[str, str]] = None,
-    subfolder: str = ""
+    subfolder: str = "",
+    send_hf_token: bool = False
 ) -> str:
     """
     Start a download in a background thread.
-    
+
+    HuggingFace URLs are routed to the huggingface_hub-backed engine
+    (core/hf_downloader.py); everything else (CivitAI, direct URLs) keeps
+    using the single-stream requests loop below, unchanged.
+
     Returns:
         download_id for tracking progress
     """
+    if 'huggingface.co' in url or url.startswith('hf://'):
+        from .sources.huggingface import parse_huggingface_url
+        parsed = parse_huggingface_url(url)
+        if parsed:
+            dest_dir = get_download_directory(category)
+            if dest_dir:
+                if subfolder:
+                    dest_dir = os.path.join(dest_dir, subfolder)
+                dest_path = os.path.join(dest_dir, filename)
+                # Same "don't clobber an existing file" contract download_model
+                # enforces below; falling through to it (rather than duplicating
+                # the error-reporting here) keeps that behavior in one place.
+                if not os.path.exists(dest_path):
+                    from .hf_downloader import start_background_hf_download
+                    return start_background_hf_download(
+                        repo_id=parsed['repo'],
+                        filename=parsed['filename'],
+                        dest_dir=dest_dir,
+                        dest_filename=filename,
+                        revision=parsed.get('branch', 'main'),
+                        send_token=send_hf_token,
+                        display_url=url,
+                    )
+
     download_id = generate_download_id()
-    
+
     def run_download():
         download_model(url, filename, category, download_id, headers, subfolder)
-    
+
     thread = threading.Thread(target=run_download, daemon=True)
     thread.start()
-    
+
     return download_id

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -454,16 +454,25 @@ def start_background_download(
                 # enforces below; falling through to it (rather than duplicating
                 # the error-reporting here) keeps that behavior in one place.
                 if not os.path.exists(dest_path):
-                    from .hf_downloader import start_background_hf_download
-                    return start_background_hf_download(
-                        repo_id=parsed['repo'],
-                        filename=parsed['filename'],
-                        dest_dir=dest_dir,
-                        dest_filename=filename,
-                        revision=parsed.get('branch', 'main'),
-                        send_token=send_hf_token,
-                        display_url=url,
-                    )
+                    try:
+                        from .hf_downloader import start_background_hf_download
+                    except ImportError as e:
+                        # Degrade to the classic single-stream engine below
+                        # rather than hard-failing the whole request -- a
+                        # missing/broken hf_downloader.py (corrupted install,
+                        # AV quarantine, etc.) shouldn't take HF downloads
+                        # down entirely when the old engine still works fine.
+                        logger.warning(f"HF engine unavailable ({e}), falling back to classic downloader")
+                    else:
+                        return start_background_hf_download(
+                            repo_id=parsed['repo'],
+                            filename=parsed['filename'],
+                            dest_dir=dest_dir,
+                            dest_filename=filename,
+                            revision=parsed.get('branch', 'main'),
+                            send_token=send_hf_token,
+                            display_url=url,
+                        )
 
     download_id = generate_download_id()
 

--- a/core/hf_downloader.py
+++ b/core/hf_downloader.py
@@ -101,20 +101,6 @@ def _staging_dir(dest_dir: str, download_id: str) -> str:
     return os.path.join(dest_dir, f'.model_linker_tmp_{download_id}')
 
 
-def _staged_bytes(staging_dir: str) -> int:
-    """Sum of every file's size under the staging directory -- the actual
-    ground truth for "how much has been downloaded so far", independent of
-    whatever progress-callback granularity the download engine provides."""
-    total = 0
-    for root, _dirs, files in os.walk(staging_dir):
-        for name in files:
-            try:
-                total += os.path.getsize(os.path.join(root, name))
-            except OSError:
-                pass  # file being written/renamed mid-stat -- picked up next poll
-    return total
-
-
 def _pipe_reader(pipe, out_queue):
     """Runs in its own thread; forwards lines from a subprocess pipe into a
     plain thread-safe queue.Queue so the caller can poll with a timeout
@@ -237,15 +223,18 @@ def download_hf_model(
     speed = 0.0
     last_cli_log = start_time
 
-    def _poll_disk_progress():
-        # Ground truth for "how much is actually downloaded" -- Xet's native
-        # progress callback is staged/coarse (a handful of calls across the
-        # whole transfer, not a smooth per-chunk stream the way the old
-        # sequential requests.iter_content() loop produced), so this doesn't
-        # depend on hf_xet's callback cadence at all. It just stats whatever
-        # bytes have actually landed under the staging directory so far.
-        nonlocal last_downloaded, last_speed_time, speed, last_cli_log
-        n = _staged_bytes(staging)
+    def _update_progress(n, total):
+        # Trust whatever the worker reports directly -- it now polls
+        # hf_xet's own group.progress() (or gets genuine incremental tqdm
+        # updates on the classic path), both of which are real numbers, not
+        # estimates. A separate disk-polling fallback used to live here; it
+        # got removed after confirming empirically that Xet buffers the
+        # whole transfer and only touches disk near completion, so polling
+        # bytes-on-disk was worse than useless -- it would have periodically
+        # overwritten a good, larger reported value with a stale small one.
+        nonlocal last_downloaded, last_speed_time, speed, last_cli_log, total_size
+        if total:
+            total_size = total
         now = time.time()
         dt = now - last_speed_time
         if dt > 0:
@@ -255,6 +244,7 @@ def download_hf_model(
             download_progress[download_id]['downloaded'] = n
             download_progress[download_id]['speed'] = int(speed)
             if total_size:
+                download_progress[download_id]['total_size'] = total_size
                 download_progress[download_id]['progress'] = min(100, int(n / total_size * 100))
         if now - last_cli_log >= 5:
             last_cli_log = now
@@ -268,7 +258,6 @@ def download_hf_model(
         try:
             line = stdout_queue.get(timeout=0.5)
         except queue_mod.Empty:
-            _poll_disk_progress()
             continue
         if line is None:
             break  # pipe closed, worker is done producing output
@@ -282,11 +271,20 @@ def download_hf_model(
 
         event = msg.get("event")
         if event == "progress":
-            if msg.get("total"):
+            n = msg.get("n")
+            if n is not None:
+                _update_progress(n, msg.get("total"))
+            elif msg.get("total"):
                 total_size = msg.get("total")
                 with download_lock:
                     download_progress[download_id]['total_size'] = total_size
-            _poll_disk_progress()
+        elif event == "log":
+            # Verbose diagnostic detail from the worker -- always printed
+            # (not throttled), so a real run's console output is enough to
+            # reconstruct exactly what happened without re-instrumenting.
+            extra = {k: v for k, v in msg.items() if k not in ('event', 't', 'message')}
+            extra_str = f" {extra}" if extra else ""
+            _safe_print(f"[Model Linker][hf-worker] {msg.get('message', '')}{extra_str}")
         elif event == "retrying":
             _safe_print(f"[Model Linker] {filename_display} is gated -- retrying with token from environment")
         elif event == "done":

--- a/core/hf_downloader.py
+++ b/core/hf_downloader.py
@@ -1,0 +1,351 @@
+"""
+HuggingFace Native Downloader
+
+Fetches files that live on huggingface.co via huggingface_hub instead of the
+hand-rolled single-stream loop in downloader.py. That loop is untouched and
+still handles CivitAI and any other direct URL -- this module only ever
+handles huggingface.co.
+
+Why this exists (see project history for the full discussion):
+- huggingface_hub is already a hard transitive dependency of ComfyUI itself
+  (via transformers), and on common platforms it pulls in hf_xet, which does
+  genuine concurrent range-get downloading. A single requests.get() stream
+  can't approach that no matter how it's tuned, so this is a real engine
+  swap, not a tuning knob.
+
+Design constraints this module exists to satisfy:
+- Anonymous by default. A token is only ever sent when the user opts in via
+  the "always send" checkbox, or an anonymous attempt comes back gated and a
+  fallback token is available in the environment.
+- The only implicit token source is HF_TOKEN / HUGGING_FACE_HUB_TOKEN read
+  from os.environ by this code. huggingface_hub's own token=True / token=None
+  resolution also reads the cached `hf auth login` file, which this project
+  deliberately stays out of -- a long-running shell login should never
+  silently leak into a ComfyUI download. So the worker is always handed an
+  explicit string or `False`, never left to resolve it on its own.
+- Cancellation is a real OS-level process kill, not a cooperative flag check
+  -- hf_hub_download owns its read loop internally and offers no hook to
+  interrupt it politely mid-transfer the way the hand-rolled loop does. The
+  actual download runs in a separate worker process (core/_hf_worker.py,
+  launched via subprocess rather than multiprocessing -- see that file's
+  docstring for why) specifically so "cancel" can be `proc.kill()`.
+- Files land in a private, dot-prefixed staging directory *inside* the real
+  destination directory, then get moved to the flat path ComfyUI expects and
+  the whole staging directory is discarded. This sidesteps two problems at
+  once: hf_hub_download's `local_dir` mode replicates the repo's internal
+  folder structure (so a file at "text_encoder/model.safetensors" in the repo
+  would otherwise land nested under the destination instead of flat in it),
+  and it avoids ever writing hf_hub_download's own `.cache/huggingface/`
+  bookkeeping folder into the real, shared, user-visible model directory,
+  where some other download could plausibly be using the same folder at the
+  same time. Staging *inside* dest_dir (not a system temp directory) keeps
+  the final move same-filesystem and atomic regardless of how the user has
+  their model folders spread across drives.
+"""
+
+import os
+import sys
+import json
+import shutil
+import subprocess
+import threading
+import time
+import logging
+import queue as queue_mod
+from typing import Optional
+
+from .downloader import (
+    download_progress,
+    download_lock,
+    cancelled_downloads,
+    format_bytes,
+    generate_download_id,
+)
+
+logger = logging.getLogger(__name__)
+
+ENV_TOKEN_VARS = ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN")
+_WORKER_SCRIPT = os.path.join(os.path.dirname(__file__), "_hf_worker.py")
+
+# How long to wait for the worker process to exit on its own after we've
+# stopped reading its stdout (EOF) or decided to cancel it.
+_PROCESS_JOIN_TIMEOUT = 5
+
+
+def _safe_print(message: str) -> None:
+    """print(), but tolerant of consoles whose active codepage can't
+    represent the glyphs below (e.g. Windows cmd.exe on cp1252) -- falls
+    back to an ASCII-safe rendering instead of crashing the download."""
+    try:
+        print(message)
+    except UnicodeEncodeError:
+        encoding = getattr(sys.stdout, 'encoding', None) or 'ascii'
+        print(message.encode(encoding, errors='replace').decode(encoding))
+
+
+def _resolve_env_token() -> Optional[str]:
+    """The only implicit auth source this module uses. Deliberately not
+    huggingface_hub's own token resolution, which also reads the cached
+    `hf auth login` file -- see module docstring."""
+    for var in ENV_TOKEN_VARS:
+        val = os.environ.get(var, '').strip()
+        if val:
+            return val
+    return None
+
+
+def _staging_dir(dest_dir: str, download_id: str) -> str:
+    # Dot-prefixed so core/scanner.py's directory walk (which already skips
+    # anything starting with '.') never sees a partially-downloaded file in
+    # here and mistakes it for an installed model.
+    return os.path.join(dest_dir, f'.model_linker_tmp_{download_id}')
+
+
+def _pipe_reader(pipe, out_queue):
+    """Runs in its own thread; forwards lines from a subprocess pipe into a
+    plain thread-safe queue.Queue so the caller can poll with a timeout
+    (and therefore notice a cancellation request) instead of blocking on
+    the pipe indefinitely."""
+    try:
+        for line in pipe:
+            out_queue.put(line)
+    except Exception:
+        pass
+    finally:
+        out_queue.put(None)  # sentinel: pipe closed
+
+
+def download_hf_model(
+    repo_id: str,
+    filename: str,
+    dest_dir: str,
+    dest_filename: str,
+    download_id: str,
+    revision: str = "main",
+    send_token: bool = False,
+    display_url: Optional[str] = None,
+) -> None:
+    """Download one file out of a HuggingFace repo straight into dest_dir,
+    flattened to dest_filename. Mutates the shared download_progress dict
+    the same way downloader.download_file does, so the existing polling
+    endpoint and frontend work completely unchanged.
+    """
+    dest_path = os.path.join(dest_dir, dest_filename)
+    staging = _staging_dir(dest_dir, download_id)
+    start_time = time.time()
+
+    with download_lock:
+        download_progress[download_id] = {
+            'status': 'starting',
+            'progress': 0,
+            'total_size': 0,
+            'downloaded': 0,
+            'filename': dest_filename,
+            'url': display_url or f"https://huggingface.co/{repo_id}/resolve/{revision}/{filename}",
+            'error': None,
+            'speed': 0,
+            'start_time': start_time,
+        }
+
+    env_token = _resolve_env_token()
+    # Checkbox on + a token available -> send it from the very first
+    # request. Otherwise start anonymous; the worker escalates on its own
+    # only if it hits a gated/401/403 response and a fallback exists.
+    initial_token = env_token if (send_token and env_token) else False
+    fallback_token = None if send_token else env_token
+
+    try:
+        os.makedirs(dest_dir, exist_ok=True)
+        os.makedirs(staging, exist_ok=True)
+    except Exception as e:
+        with download_lock:
+            download_progress[download_id]['status'] = 'error'
+            download_progress[download_id]['error'] = f"Could not create download directory: {e}"
+        return
+
+    filename_display = os.path.basename(dest_filename)
+    _safe_print(f"\n[Model Linker] Starting download: {filename_display}")
+    _safe_print(f"[Model Linker] Source: HuggingFace ({repo_id})")
+
+    request = {
+        "repo_id": repo_id,
+        "filename": filename,
+        "revision": revision,
+        "local_dir": staging,
+        "token": initial_token,
+        "fallback_token": fallback_token,
+    }
+
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, _WORKER_SCRIPT],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+    except Exception as e:
+        shutil.rmtree(staging, ignore_errors=True)
+        with download_lock:
+            download_progress[download_id]['status'] = 'error'
+            download_progress[download_id]['error'] = f"Could not start download worker: {e}"
+        _safe_print(f"[Model Linker] ✗ Download failed: {filename_display}")
+        _safe_print(f"[Model Linker] Error: Could not start download worker: {e}")
+        return
+
+    try:
+        proc.stdin.write(json.dumps(request) + "\n")
+        proc.stdin.flush()
+        proc.stdin.close()
+    except Exception:
+        pass  # worker will surface its own error over stdout if this mattered
+
+    with download_lock:
+        download_progress[download_id]['status'] = 'downloading'
+
+    stdout_queue: queue_mod.Queue = queue_mod.Queue()
+    stderr_lines = []
+    reader = threading.Thread(target=_pipe_reader, args=(proc.stdout, stdout_queue), daemon=True)
+    reader.start()
+    stderr_reader = threading.Thread(
+        target=lambda: stderr_lines.extend(proc.stderr.readlines() if proc.stderr else []),
+        daemon=True,
+    )
+    stderr_reader.start()
+
+    result_path = None
+    error_msg = None
+    cancelled = False
+    last_downloaded = 0
+    last_speed_time = start_time
+    speed = 0.0
+    last_cli_log = start_time
+
+    while True:
+        if download_id in cancelled_downloads:
+            cancelled = True
+            break
+        try:
+            line = stdout_queue.get(timeout=0.5)
+        except queue_mod.Empty:
+            continue
+        if line is None:
+            break  # pipe closed, worker is done producing output
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except ValueError:
+            continue
+
+        event = msg.get("event")
+        if event == "progress":
+            n, total = msg.get("n", 0), msg.get("total", 0)
+            now = time.time()
+            dt = now - last_speed_time
+            if dt > 0:
+                speed = (n - last_downloaded) / dt
+            last_downloaded, last_speed_time = n, now
+            with download_lock:
+                download_progress[download_id]['downloaded'] = n
+                download_progress[download_id]['total_size'] = total
+                download_progress[download_id]['speed'] = int(speed)
+                if total:
+                    download_progress[download_id]['progress'] = int(n / total * 100)
+            if now - last_cli_log >= 5:
+                last_cli_log = now
+                total_str = format_bytes(total) if total else "?"
+                _safe_print(f"[Model Linker] Progress: {format_bytes(n)} / {total_str} - {format_bytes(int(speed))}/s")
+        elif event == "retrying":
+            _safe_print(f"[Model Linker] {filename_display} is gated -- retrying with token from environment")
+        elif event == "done":
+            result_path = msg.get("path")
+        elif event == "error":
+            error_msg = msg.get("message")
+
+    if download_id in cancelled_downloads:
+        cancelled = True
+
+    if cancelled:
+        proc.terminate()
+        try:
+            proc.wait(timeout=_PROCESS_JOIN_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                proc.wait(timeout=_PROCESS_JOIN_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                pass
+        shutil.rmtree(staging, ignore_errors=True)
+        with download_lock:
+            download_progress[download_id]['status'] = 'cancelled'
+        _safe_print(f"[Model Linker] Cancelled: {filename_display} - incomplete file deleted")
+        cancelled_downloads.discard(download_id)
+        return
+
+    try:
+        proc.wait(timeout=_PROCESS_JOIN_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+    if result_path and os.path.exists(result_path):
+        try:
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            os.replace(result_path, dest_path)
+        except Exception as e:
+            shutil.rmtree(staging, ignore_errors=True)
+            with download_lock:
+                download_progress[download_id]['status'] = 'error'
+                download_progress[download_id]['error'] = f"Downloaded but could not move into place: {e}"
+            _safe_print(f"[Model Linker] ✗ Download failed: {filename_display}")
+            _safe_print(f"[Model Linker] Error: could not move into place: {e}")
+            return
+
+        shutil.rmtree(staging, ignore_errors=True)
+        size = os.path.getsize(dest_path)
+        elapsed = time.time() - start_time
+        avg_speed = size / elapsed if elapsed > 0 else 0
+        with download_lock:
+            download_progress[download_id]['status'] = 'completed'
+            download_progress[download_id]['progress'] = 100
+            download_progress[download_id]['speed'] = 0
+        _safe_print(f"[Model Linker] ✓ Download complete: {filename_display}")
+        _safe_print(f"[Model Linker] Size: {format_bytes(size)}, Time: {elapsed:.1f}s, Avg speed: {format_bytes(int(avg_speed))}/s")
+        return
+
+    # Error path
+    shutil.rmtree(staging, ignore_errors=True)
+    stderr_tail = ''.join(stderr_lines).strip()
+    final_error = error_msg or (stderr_tail[-500:] if stderr_tail else None) or "Download failed for an unknown reason"
+    with download_lock:
+        download_progress[download_id]['status'] = 'error'
+        download_progress[download_id]['error'] = final_error
+    _safe_print(f"[Model Linker] ✗ Download failed: {filename_display}")
+    _safe_print(f"[Model Linker] Error: {final_error}")
+
+
+def start_background_hf_download(
+    repo_id: str,
+    filename: str,
+    dest_dir: str,
+    dest_filename: str,
+    revision: str = "main",
+    send_token: bool = False,
+    display_url: Optional[str] = None,
+) -> str:
+    """Start a HuggingFace download in a background thread. Returns a
+    download_id usable with the same /model_linker/progress polling
+    endpoint the legacy downloader uses."""
+    download_id = generate_download_id()
+
+    def run():
+        download_hf_model(
+            repo_id, filename, dest_dir, dest_filename, download_id,
+            revision=revision, send_token=send_token, display_url=display_url,
+        )
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    return download_id

--- a/core/hf_downloader.py
+++ b/core/hf_downloader.py
@@ -101,6 +101,20 @@ def _staging_dir(dest_dir: str, download_id: str) -> str:
     return os.path.join(dest_dir, f'.model_linker_tmp_{download_id}')
 
 
+def _staged_bytes(staging_dir: str) -> int:
+    """Sum of every file's size under the staging directory -- the actual
+    ground truth for "how much has been downloaded so far", independent of
+    whatever progress-callback granularity the download engine provides."""
+    total = 0
+    for root, _dirs, files in os.walk(staging_dir):
+        for name in files:
+            try:
+                total += os.path.getsize(os.path.join(root, name))
+            except OSError:
+                pass  # file being written/renamed mid-stat -- picked up next poll
+    return total
+
+
 def _pipe_reader(pipe, out_queue):
     """Runs in its own thread; forwards lines from a subprocess pipe into a
     plain thread-safe queue.Queue so the caller can poll with a timeout
@@ -217,10 +231,35 @@ def download_hf_model(
     result_path = None
     error_msg = None
     cancelled = False
+    total_size = 0
     last_downloaded = 0
     last_speed_time = start_time
     speed = 0.0
     last_cli_log = start_time
+
+    def _poll_disk_progress():
+        # Ground truth for "how much is actually downloaded" -- Xet's native
+        # progress callback is staged/coarse (a handful of calls across the
+        # whole transfer, not a smooth per-chunk stream the way the old
+        # sequential requests.iter_content() loop produced), so this doesn't
+        # depend on hf_xet's callback cadence at all. It just stats whatever
+        # bytes have actually landed under the staging directory so far.
+        nonlocal last_downloaded, last_speed_time, speed, last_cli_log
+        n = _staged_bytes(staging)
+        now = time.time()
+        dt = now - last_speed_time
+        if dt > 0:
+            speed = max(0.0, (n - last_downloaded) / dt)
+        last_downloaded, last_speed_time = n, now
+        with download_lock:
+            download_progress[download_id]['downloaded'] = n
+            download_progress[download_id]['speed'] = int(speed)
+            if total_size:
+                download_progress[download_id]['progress'] = min(100, int(n / total_size * 100))
+        if now - last_cli_log >= 5:
+            last_cli_log = now
+            total_str = format_bytes(total_size) if total_size else "?"
+            _safe_print(f"[Model Linker] Progress: {format_bytes(n)} / {total_str} - {format_bytes(int(speed))}/s")
 
     while True:
         if download_id in cancelled_downloads:
@@ -229,6 +268,7 @@ def download_hf_model(
         try:
             line = stdout_queue.get(timeout=0.5)
         except queue_mod.Empty:
+            _poll_disk_progress()
             continue
         if line is None:
             break  # pipe closed, worker is done producing output
@@ -242,22 +282,11 @@ def download_hf_model(
 
         event = msg.get("event")
         if event == "progress":
-            n, total = msg.get("n", 0), msg.get("total", 0)
-            now = time.time()
-            dt = now - last_speed_time
-            if dt > 0:
-                speed = (n - last_downloaded) / dt
-            last_downloaded, last_speed_time = n, now
-            with download_lock:
-                download_progress[download_id]['downloaded'] = n
-                download_progress[download_id]['total_size'] = total
-                download_progress[download_id]['speed'] = int(speed)
-                if total:
-                    download_progress[download_id]['progress'] = int(n / total * 100)
-            if now - last_cli_log >= 5:
-                last_cli_log = now
-                total_str = format_bytes(total) if total else "?"
-                _safe_print(f"[Model Linker] Progress: {format_bytes(n)} / {total_str} - {format_bytes(int(speed))}/s")
+            if msg.get("total"):
+                total_size = msg.get("total")
+                with download_lock:
+                    download_progress[download_id]['total_size'] = total_size
+            _poll_disk_progress()
         elif event == "retrying":
             _safe_print(f"[Model Linker] {filename_display} is gated -- retrying with token from environment")
         elif event == "done":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ requires-python = ">=3.8"
 dependencies = [
     "requests>=2.28.0",
     "aiohttp>=3.8.0",
+    # Matches the floor transformers itself requires, so this never conflicts
+    # with what's already resident in a ComfyUI install.
+    "huggingface_hub>=1.5.0,<2.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.28.0
 aiohttp>=3.8.0
+huggingface_hub>=1.5.0,<2.0

--- a/tests/test_hf_downloader.py
+++ b/tests/test_hf_downloader.py
@@ -1,0 +1,417 @@
+"""
+Tests for core/hf_downloader.py and core/_hf_worker.py — run with:
+    python tests/test_hf_downloader.py
+
+subprocess.Popen is mocked throughout, so these never actually spawn a
+worker process or touch the network. The _hf_worker tests import it
+directly and exercise main() in-process instead (real subprocess behavior
+is out of scope for a unit test -- see the module docstrings for why
+_hf_worker.py has to be launched as a separate process by real ComfyUI
+rather than imported normally).
+
+The _hf_worker tests need huggingface_hub importable; they skip themselves
+(printed as SKIP, not a failure) if it isn't installed in whatever
+environment runs this file.
+"""
+
+import os
+import sys
+import io
+import json
+import shutil
+import tempfile
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Stub folder_paths so core.downloader (imported transitively by
+# core.hf_downloader) doesn't need a real ComfyUI install, same convention
+# as test_workflow_analyzer.py.
+if 'folder_paths' not in sys.modules:
+    fp = types.ModuleType('folder_paths')
+    fp.get_folder_paths = lambda key: []
+    sys.modules['folder_paths'] = fp
+
+from core import hf_downloader as hfd
+from core.downloader import download_progress, download_lock, cancelled_downloads
+
+
+class FakeStream:
+    """Stand-in for a subprocess pipe: iterable line-by-line, and supports
+    .readlines() the way hf_downloader's stderr drain expects."""
+
+    def __init__(self, lines=()):
+        self._lines = list(lines)
+
+    def __iter__(self):
+        return iter(self._lines)
+
+    def readlines(self):
+        return self._lines
+
+
+class FakeProcess:
+    """Stand-in for subprocess.Popen's return value."""
+
+    def __init__(self, stdout_lines, stderr_lines=()):
+        self.stdin = mock.Mock()
+        self.stdout = FakeStream(stdout_lines)
+        self.stderr = FakeStream(stderr_lines)
+        self.terminated = False
+        self.killed = False
+
+    def wait(self, timeout=None):
+        return 0
+
+    def poll(self):
+        return 0
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+def _forget(download_id):
+    with download_lock:
+        download_progress.pop(download_id, None)
+    cancelled_downloads.discard(download_id)
+
+
+def _with_env(**env):
+    """Context manager: set env vars, restore whatever was there after."""
+
+    class _Ctx:
+        def __enter__(self):
+            self._saved = {k: os.environ.get(k) for k in env}
+            for k, v in env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+            return self
+
+        def __exit__(self, *exc):
+            for k, v in self._saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+    return _Ctx()
+
+
+# --- env token resolution -----------------------------------------------
+
+def test_resolve_env_token_prefers_hf_token_over_hugging_face_hub_token():
+    with _with_env(HF_TOKEN='tok-a', HUGGING_FACE_HUB_TOKEN='tok-b'):
+        assert hfd._resolve_env_token() == 'tok-a'
+
+
+def test_resolve_env_token_falls_back_to_hugging_face_hub_token():
+    with _with_env(HF_TOKEN=None, HUGGING_FACE_HUB_TOKEN='tok-b'):
+        assert hfd._resolve_env_token() == 'tok-b'
+
+
+def test_resolve_env_token_none_when_unset_or_blank():
+    with _with_env(HF_TOKEN=None, HUGGING_FACE_HUB_TOKEN=None):
+        assert hfd._resolve_env_token() is None
+    with _with_env(HF_TOKEN='   ', HUGGING_FACE_HUB_TOKEN=None):
+        assert hfd._resolve_env_token() is None
+
+
+# --- orchestrator: staging / move / cleanup ------------------------------
+
+def test_happy_path_moves_file_flat_and_removes_staging_dir():
+    tmp = tempfile.mkdtemp(prefix='hfdl_test_')
+    download_id = 'happytest'
+    try:
+        dest_dir = os.path.join(tmp, 'checkpoints')
+        os.makedirs(dest_dir, exist_ok=True)
+        staging = hfd._staging_dir(dest_dir, download_id)
+
+        def fake_popen(*args, **kwargs):
+            # Simulate what the real worker would have produced by now:
+            # the repo's nested layout replicated under the staging dir.
+            nested = os.path.join(staging, 'text_encoder')
+            os.makedirs(nested, exist_ok=True)
+            staged_file = os.path.join(nested, 'model.safetensors')
+            with open(staged_file, 'wb') as f:
+                f.write(b'x' * 100)
+            lines = [
+                json.dumps({"event": "progress", "n": 50, "total": 100}) + "\n",
+                json.dumps({"event": "progress", "n": 100, "total": 100}) + "\n",
+                json.dumps({"event": "done", "path": staged_file}) + "\n",
+            ]
+            return FakeProcess(lines)
+
+        with mock.patch.object(hfd.subprocess, 'Popen', side_effect=fake_popen):
+            hfd.download_hf_model(
+                repo_id='someuser/somerepo',
+                filename='text_encoder/model.safetensors',
+                dest_dir=dest_dir,
+                dest_filename='model.safetensors',  # flattened, no subfolder
+                download_id=download_id,
+            )
+
+        dest_path = os.path.join(dest_dir, 'model.safetensors')
+        assert os.path.exists(dest_path), 'file should land flat at dest_dir, not nested'
+        assert not os.path.exists(staging), 'staging dir (incl. its .cache/huggingface) must be gone'
+
+        with download_lock:
+            info = dict(download_progress.get(download_id) or {})
+        assert info.get('status') == 'completed'
+        assert info.get('progress') == 100
+    finally:
+        _forget(download_id)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_error_event_marks_progress_error_and_cleans_staging():
+    tmp = tempfile.mkdtemp(prefix='hfdl_test_')
+    download_id = 'errortest'
+    try:
+        dest_dir = os.path.join(tmp, 'checkpoints')
+        os.makedirs(dest_dir, exist_ok=True)
+        staging = hfd._staging_dir(dest_dir, download_id)
+
+        def fake_popen(*args, **kwargs):
+            os.makedirs(staging, exist_ok=True)  # worker still creates it before failing
+            lines = [json.dumps({"event": "error", "message": "gated, no token available"}) + "\n"]
+            return FakeProcess(lines)
+
+        with mock.patch.object(hfd.subprocess, 'Popen', side_effect=fake_popen):
+            hfd.download_hf_model(
+                repo_id='someuser/gatedrepo',
+                filename='model.safetensors',
+                dest_dir=dest_dir,
+                dest_filename='model.safetensors',
+                download_id=download_id,
+            )
+
+        assert not os.path.exists(staging)
+        with download_lock:
+            info = dict(download_progress.get(download_id) or {})
+        assert info.get('status') == 'error'
+        assert 'gated' in (info.get('error') or '')
+    finally:
+        _forget(download_id)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_cancellation_kills_process_and_cleans_staging():
+    tmp = tempfile.mkdtemp(prefix='hfdl_test_')
+    download_id = 'canceltest'
+    try:
+        dest_dir = os.path.join(tmp, 'checkpoints')
+        os.makedirs(dest_dir, exist_ok=True)
+        staging = hfd._staging_dir(dest_dir, download_id)
+
+        captured = {}
+
+        def fake_popen(*args, **kwargs):
+            os.makedirs(staging, exist_ok=True)
+            # Mark cancelled "mid-transfer" -- before the loop consumes any
+            # progress lines -- to simulate a cancel click during download.
+            cancelled_downloads.add(download_id)
+            proc = FakeProcess([json.dumps({"event": "progress", "n": 1, "total": 100}) + "\n"])
+            captured['proc'] = proc
+            return proc
+
+        with mock.patch.object(hfd.subprocess, 'Popen', side_effect=fake_popen):
+            hfd.download_hf_model(
+                repo_id='someuser/somerepo',
+                filename='model.safetensors',
+                dest_dir=dest_dir,
+                dest_filename='model.safetensors',
+                download_id=download_id,
+            )
+
+        assert not os.path.exists(staging)
+        assert captured['proc'].terminated
+        with download_lock:
+            info = dict(download_progress.get(download_id) or {})
+        assert info.get('status') == 'cancelled'
+        assert download_id not in cancelled_downloads, 'cancel flag should be consumed, not linger'
+    finally:
+        _forget(download_id)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+# --- dispatch: downloader.start_background_download routes HF vs. legacy --
+
+def test_dispatch_routes_huggingface_url_to_hf_engine():
+    from core import downloader as dl
+
+    tmp = tempfile.mkdtemp(prefix='dispatch_test_')
+    try:
+        with mock.patch.object(dl, 'get_download_directory', return_value=tmp), \
+             mock.patch('core.hf_downloader.start_background_hf_download', return_value='fake-id') as mocked:
+            result = dl.start_background_download(
+                url='https://huggingface.co/someuser/somerepo/resolve/main/model.safetensors',
+                filename='model.safetensors',
+                category='checkpoints',
+            )
+        assert result == 'fake-id'
+        assert mocked.called
+        _, kwargs = mocked.call_args
+        assert kwargs['repo_id'] == 'someuser/somerepo'
+        assert kwargs['filename'] == 'model.safetensors'
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_dispatch_leaves_civitai_url_on_legacy_path():
+    from core import downloader as dl
+
+    tmp = tempfile.mkdtemp(prefix='dispatch_test_')
+    try:
+        with mock.patch.object(dl, 'get_download_directory', return_value=tmp), \
+             mock.patch('core.hf_downloader.start_background_hf_download') as mocked, \
+             mock.patch.object(dl, 'download_model') as mocked_legacy:
+            download_id = dl.start_background_download(
+                url='https://civitai.com/api/download/models/12345',
+                filename='model.safetensors',
+                category='checkpoints',
+            )
+            # start_background_download spawns download_model on a thread;
+            # give it a beat to run.
+            import time
+            for _ in range(50):
+                if mocked_legacy.called:
+                    break
+                time.sleep(0.02)
+        assert not mocked.called, 'CivitAI URLs must never reach the HF engine'
+        assert mocked_legacy.called
+        _forget(download_id)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+# --- _hf_worker: the anonymous-first / escalate-only-when-mandatory logic -
+
+def _fake_response(status_code):
+    """HfHubHTTPError.__init__ reads response.headers.get(...) and
+    response.request, not just .status_code -- a bare SimpleNamespace(
+    status_code=...) blows up inside the exception's own constructor.
+    Confirmed against the installed huggingface_hub's actual source rather
+    than assumed."""
+    return SimpleNamespace(status_code=status_code, headers={}, request=None)
+
+
+def _run_worker_main(request, hf_hub_download_mock):
+    """Runs core._hf_worker.main() in-process with stdin/stdout swapped
+    for StringIO buffers and huggingface_hub.hf_hub_download mocked out.
+    Returns the list of parsed JSON events it emitted."""
+    from core import _hf_worker as worker
+
+    old_stdin, old_stdout = sys.stdin, sys.stdout
+    sys.stdin = io.StringIO(json.dumps(request) + "\n")
+    sys.stdout = io.StringIO()
+    try:
+        with mock.patch('huggingface_hub.hf_hub_download', hf_hub_download_mock):
+            worker.main()
+        output = sys.stdout.getvalue()
+    finally:
+        sys.stdin, sys.stdout = old_stdin, old_stdout
+
+    return [json.loads(line) for line in output.splitlines() if line.strip()]
+
+
+def test_worker_escalates_once_on_gated_response_when_fallback_available():
+    try:
+        import huggingface_hub  # noqa: F401
+        from huggingface_hub.errors import HfHubHTTPError
+    except ImportError:
+        print('SKIP test_worker_escalates_once_on_gated_response_when_fallback_available '
+              '(huggingface_hub not installed)')
+        return
+
+    calls = []
+
+    def fake_download(**kwargs):
+        calls.append(kwargs['token'])
+        if kwargs['token'] is False:
+            err = HfHubHTTPError('gated', response=_fake_response(403))
+            raise err
+        return '/staging/model.safetensors'
+
+    events = _run_worker_main(
+        {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
+         "token": False, "fallback_token": "env-token-value"},
+        fake_download,
+    )
+
+    assert calls == [False, 'env-token-value'], 'must try anonymous first, only escalate after a 403'
+    kinds = [e['event'] for e in events]
+    assert 'retrying' in kinds
+    assert events[-1] == {"event": "done", "path": "/staging/model.safetensors"}
+
+
+def test_worker_does_not_retry_without_a_fallback_token():
+    try:
+        import huggingface_hub  # noqa: F401
+        from huggingface_hub.errors import HfHubHTTPError
+    except ImportError:
+        print('SKIP test_worker_does_not_retry_without_a_fallback_token (huggingface_hub not installed)')
+        return
+
+    calls = []
+
+    def fake_download(**kwargs):
+        calls.append(kwargs['token'])
+        raise HfHubHTTPError('gated', response=_fake_response(403))
+
+    events = _run_worker_main(
+        {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
+         "token": False, "fallback_token": None},
+        fake_download,
+    )
+
+    assert calls == [False], 'no token to fall back to -- must not retry'
+    assert events[-1]['event'] == 'error'
+    assert 'gated' in events[-1]['message'].lower()
+
+
+def test_worker_never_escalates_when_a_token_was_already_sent():
+    try:
+        import huggingface_hub  # noqa: F401
+        from huggingface_hub.errors import HfHubHTTPError
+    except ImportError:
+        print('SKIP test_worker_never_escalates_when_a_token_was_already_sent (huggingface_hub not installed)')
+        return
+
+    calls = []
+
+    def fake_download(**kwargs):
+        calls.append(kwargs['token'])
+        raise HfHubHTTPError('unauthorized', response=_fake_response(401))
+
+    # "Always send" checkbox path: token is already a real string on the
+    # first attempt, so there is nothing left to escalate to even though a
+    # fallback_token happens to be set -- a rejected token must not retry.
+    events = _run_worker_main(
+        {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
+         "token": "already-sent-token", "fallback_token": "env-token-value"},
+        fake_download,
+    )
+
+    assert calls == ['already-sent-token']
+    assert events[-1]['event'] == 'error'
+    assert 'rejected' in events[-1]['message'].lower()
+
+
+if __name__ == '__main__':
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith('test_') and callable(fn):
+            try:
+                fn()
+                print(f'PASS {name}')
+            except AssertionError as e:
+                failures += 1
+                print(f'FAIL {name}: {e}')
+    sys.exit(1 if failures else 0)

--- a/tests/test_hf_downloader.py
+++ b/tests/test_hf_downloader.py
@@ -21,6 +21,7 @@ import json
 import shutil
 import tempfile
 import types
+import contextlib
 from types import SimpleNamespace
 from unittest import mock
 
@@ -292,6 +293,12 @@ def test_dispatch_leaves_civitai_url_on_legacy_path():
 
 
 # --- _hf_worker: the anonymous-first / escalate-only-when-mandatory logic -
+#
+# The auth checkpoint lives around get_hf_file_metadata() (the first network
+# call main() makes), not around hf_hub_download() -- the same resolved
+# token is then reused for whichever download path (Xet or classic) gets
+# taken afterward, since HF enforces gating consistently across both
+# endpoints. See _hf_worker.py's module docstring for the full picture.
 
 def _fake_response(status_code):
     """HfHubHTTPError.__init__ reads response.headers.get(...) and
@@ -302,17 +309,26 @@ def _fake_response(status_code):
     return SimpleNamespace(status_code=status_code, headers={}, request=None)
 
 
-def _run_worker_main(request, hf_hub_download_mock):
-    """Runs core._hf_worker.main() in-process with stdin/stdout swapped
-    for StringIO buffers and huggingface_hub.hf_hub_download mocked out.
-    Returns the list of parsed JSON events it emitted."""
+def _fake_metadata(size=100, xet_file_data=None, etag='abc123'):
+    return SimpleNamespace(size=size, etag=etag, xet_file_data=xet_file_data)
+
+
+def _run_worker_main(request, get_metadata_mock, hf_hub_download_mock=None):
+    """Runs core._hf_worker.main() in-process with stdin/stdout swapped for
+    StringIO buffers and huggingface_hub's network-calling functions mocked
+    out. Returns the list of parsed JSON events it emitted."""
     from core import _hf_worker as worker
 
     old_stdin, old_stdout = sys.stdin, sys.stdout
     sys.stdin = io.StringIO(json.dumps(request) + "\n")
     sys.stdout = io.StringIO()
     try:
-        with mock.patch('huggingface_hub.hf_hub_download', hf_hub_download_mock):
+        patches = [mock.patch('huggingface_hub.get_hf_file_metadata', get_metadata_mock)]
+        if hf_hub_download_mock is not None:
+            patches.append(mock.patch('huggingface_hub.hf_hub_download', hf_hub_download_mock))
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
             worker.main()
         output = sys.stdout.getvalue()
     finally:
@@ -321,54 +337,60 @@ def _run_worker_main(request, hf_hub_download_mock):
     return [json.loads(line) for line in output.splitlines() if line.strip()]
 
 
-def test_worker_escalates_once_on_gated_response_when_fallback_available():
+def _skip_without_huggingface_hub(test_name):
     try:
         import huggingface_hub  # noqa: F401
-        from huggingface_hub.errors import HfHubHTTPError
+        from huggingface_hub.errors import HfHubHTTPError  # noqa: F401
+        return False
     except ImportError:
-        print('SKIP test_worker_escalates_once_on_gated_response_when_fallback_available '
-              '(huggingface_hub not installed)')
+        print(f'SKIP {test_name} (huggingface_hub not installed)')
+        return True
+
+
+def test_worker_escalates_metadata_fetch_once_on_gated_response_when_fallback_available():
+    if _skip_without_huggingface_hub('test_worker_escalates_metadata_fetch_once_on_gated_response_when_fallback_available'):
         return
+    from huggingface_hub.errors import HfHubHTTPError
 
     calls = []
 
+    def fake_get_metadata(url, token=None, **kwargs):
+        calls.append(token)
+        if token is False:
+            raise HfHubHTTPError('gated', response=_fake_response(403))
+        return _fake_metadata()  # xet_file_data=None -> classic path
+
     def fake_download(**kwargs):
-        calls.append(kwargs['token'])
-        if kwargs['token'] is False:
-            err = HfHubHTTPError('gated', response=_fake_response(403))
-            raise err
+        assert kwargs['token'] == 'env-token-value', 'the escalated token must carry through to the download itself'
         return '/staging/model.safetensors'
 
     events = _run_worker_main(
         {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
          "token": False, "fallback_token": "env-token-value"},
-        fake_download,
+        fake_get_metadata, fake_download,
     )
 
     assert calls == [False, 'env-token-value'], 'must try anonymous first, only escalate after a 403'
     kinds = [e['event'] for e in events]
     assert 'retrying' in kinds
-    assert events[-1] == {"event": "done", "path": "/staging/model.safetensors"}
+    assert events[-1]["event"] == "done" and events[-1]["path"] == "/staging/model.safetensors"
 
 
-def test_worker_does_not_retry_without_a_fallback_token():
-    try:
-        import huggingface_hub  # noqa: F401
-        from huggingface_hub.errors import HfHubHTTPError
-    except ImportError:
-        print('SKIP test_worker_does_not_retry_without_a_fallback_token (huggingface_hub not installed)')
+def test_worker_does_not_retry_metadata_without_a_fallback_token():
+    if _skip_without_huggingface_hub('test_worker_does_not_retry_metadata_without_a_fallback_token'):
         return
+    from huggingface_hub.errors import HfHubHTTPError
 
     calls = []
 
-    def fake_download(**kwargs):
-        calls.append(kwargs['token'])
+    def fake_get_metadata(url, token=None, **kwargs):
+        calls.append(token)
         raise HfHubHTTPError('gated', response=_fake_response(403))
 
     events = _run_worker_main(
         {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
          "token": False, "fallback_token": None},
-        fake_download,
+        fake_get_metadata,
     )
 
     assert calls == [False], 'no token to fall back to -- must not retry'
@@ -376,18 +398,15 @@ def test_worker_does_not_retry_without_a_fallback_token():
     assert 'gated' in events[-1]['message'].lower()
 
 
-def test_worker_never_escalates_when_a_token_was_already_sent():
-    try:
-        import huggingface_hub  # noqa: F401
-        from huggingface_hub.errors import HfHubHTTPError
-    except ImportError:
-        print('SKIP test_worker_never_escalates_when_a_token_was_already_sent (huggingface_hub not installed)')
+def test_worker_never_escalates_metadata_when_a_token_was_already_sent():
+    if _skip_without_huggingface_hub('test_worker_never_escalates_metadata_when_a_token_was_already_sent'):
         return
+    from huggingface_hub.errors import HfHubHTTPError
 
     calls = []
 
-    def fake_download(**kwargs):
-        calls.append(kwargs['token'])
+    def fake_get_metadata(url, token=None, **kwargs):
+        calls.append(token)
         raise HfHubHTTPError('unauthorized', response=_fake_response(401))
 
     # "Always send" checkbox path: token is already a real string on the
@@ -396,12 +415,128 @@ def test_worker_never_escalates_when_a_token_was_already_sent():
     events = _run_worker_main(
         {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
          "token": "already-sent-token", "fallback_token": "env-token-value"},
-        fake_download,
+        fake_get_metadata,
     )
 
     assert calls == ['already-sent-token']
     assert events[-1]['event'] == 'error'
     assert 'rejected' in events[-1]['message'].lower()
+
+
+def test_worker_non_xet_file_uses_hf_hub_download():
+    if _skip_without_huggingface_hub('test_worker_non_xet_file_uses_hf_hub_download'):
+        return
+
+    def fake_get_metadata(url, token=None, **kwargs):
+        return _fake_metadata(xet_file_data=None)  # not Xet-hosted
+
+    def fake_download(**kwargs):
+        assert kwargs['token'] is False
+        return '/staging/plain.safetensors'
+
+    events = _run_worker_main(
+        {"repo_id": "u/r", "filename": "plain.safetensors", "local_dir": "/staging",
+         "token": False, "fallback_token": None},
+        fake_get_metadata, fake_download,
+    )
+
+    assert events[-1]["event"] == "done" and events[-1]["path"] == "/staging/plain.safetensors"
+
+
+def test_worker_xet_path_downloads_and_reports_real_progress():
+    if _skip_without_huggingface_hub('test_worker_xet_path_downloads_and_reports_real_progress'):
+        return
+
+    tmp = tempfile.mkdtemp(prefix='xet_worker_test_')
+    try:
+        xet_data = SimpleNamespace(file_hash='deadbeef', refresh_route='https://example.com/refresh')
+
+        def fake_get_metadata(url, token=None, **kwargs):
+            return _fake_metadata(size=1000, xet_file_data=xet_data)
+
+        class _FakeGroup:
+            """Mirrors the real hf_xet behavior confirmed empirically:
+            nothing lands on disk until wait_to_finish() completes, and
+            progress() returns an increasing sequence across calls."""
+
+            def __init__(self):
+                self._sequence = [0, 400, 1000]
+                self._i = 0
+                self._dest = None
+
+            def start_download_file(self, file_info, dest_path):
+                self._dest = dest_path
+
+            def progress(self):
+                completed = self._sequence[min(self._i, len(self._sequence) - 1)]
+                self._i += 1
+                return SimpleNamespace(total_bytes_completed=completed, total_bytes=1000,
+                                        total_bytes_completion_rate=500.0)
+
+            def wait_to_finish(self):
+                import time as _time
+                _time.sleep(0.35)  # give the 0.3s poll loop at least one real tick
+                with open(self._dest, 'wb') as f:
+                    f.write(b'x' * 1000)
+                return SimpleNamespace(files=1)
+
+        fake_group = _FakeGroup()
+        fake_session = mock.Mock()
+        fake_session.new_file_download_group.return_value = fake_group
+        fake_hf_xet = mock.Mock()
+        fake_hf_xet.XetSession.return_value = fake_session
+        fake_hf_xet.XetFileInfo = lambda hash, file_size=None: SimpleNamespace(hash=hash, file_size=file_size)
+
+        saved_hf_xet = sys.modules.get('hf_xet')
+        sys.modules['hf_xet'] = fake_hf_xet
+        try:
+            with mock.patch('huggingface_hub.utils._xet.refresh_xet_connection_info',
+                             return_value=SimpleNamespace(endpoint='https://cas.example.com',
+                                                           access_token='tok', expiration_unix_epoch=0)):
+                events = _run_worker_main(
+                    {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": tmp,
+                     "token": False, "fallback_token": None},
+                    fake_get_metadata,
+                )
+        finally:
+            if saved_hf_xet is not None:
+                sys.modules['hf_xet'] = saved_hf_xet
+            else:
+                sys.modules.pop('hf_xet', None)
+
+        kinds = [e['event'] for e in events]
+        assert 'done' in kinds
+        progress_events = [e for e in events if e['event'] == 'progress']
+        assert any(e['n'] > 0 for e in progress_events), 'must report real, nonzero progress before completion'
+        done = [e for e in events if e['event'] == 'done'][0]
+        assert os.path.exists(done['path'])
+        assert os.path.getsize(done['path']) == 1000
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_worker_xet_path_failure_falls_back_to_hf_hub_download():
+    if _skip_without_huggingface_hub('test_worker_xet_path_failure_falls_back_to_hf_hub_download'):
+        return
+
+    xet_data = SimpleNamespace(file_hash='deadbeef', refresh_route='https://example.com/refresh')
+
+    def fake_get_metadata(url, token=None, **kwargs):
+        return _fake_metadata(size=1000, xet_file_data=xet_data)
+
+    def fake_download(**kwargs):
+        return '/staging/fallback.safetensors'
+
+    with mock.patch('huggingface_hub.utils._xet.refresh_xet_connection_info',
+                     side_effect=RuntimeError('xet connection refused')):
+        events = _run_worker_main(
+            {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
+             "token": False, "fallback_token": None},
+            fake_get_metadata, fake_download,
+        )
+
+    assert events[-1]["event"] == "done" and events[-1]["path"] == "/staging/fallback.safetensors"
+    assert any(e['event'] == 'log' and 'falling back' in e.get('message', '') for e in events)
 
 
 if __name__ == '__main__':

--- a/tests/test_hf_downloader.py
+++ b/tests/test_hf_downloader.py
@@ -21,7 +21,6 @@ import json
 import shutil
 import tempfile
 import types
-import contextlib
 from types import SimpleNamespace
 from unittest import mock
 
@@ -294,11 +293,14 @@ def test_dispatch_leaves_civitai_url_on_legacy_path():
 
 # --- _hf_worker: the anonymous-first / escalate-only-when-mandatory logic -
 #
-# The auth checkpoint lives around get_hf_file_metadata() (the first network
-# call main() makes), not around hf_hub_download() -- the same resolved
-# token is then reused for whichever download path (Xet or classic) gets
-# taken afterward, since HF enforces gating consistently across both
-# endpoints. See _hf_worker.py's module docstring for the full picture.
+# Wraps hf_hub_download() itself -- the first (and only) network call
+# main() makes. No separate metadata pre-fetch or private hf_xet API: see
+# _hf_worker.py's module docstring for why the earlier custom XetSession
+# reimplementation got retired (broke on a different huggingface_hub version
+# in the wild) in favor of hf_hub_download's own tqdm_class hook, which
+# turns out to give real incremental progress once the shim implements its
+# (undocumented but stable) update_transfer contract -- covered separately
+# below in the _ProgressTqdm tests.
 
 def _fake_response(status_code):
     """HfHubHTTPError.__init__ reads response.headers.get(...) and
@@ -309,26 +311,17 @@ def _fake_response(status_code):
     return SimpleNamespace(status_code=status_code, headers={}, request=None)
 
 
-def _fake_metadata(size=100, xet_file_data=None, etag='abc123'):
-    return SimpleNamespace(size=size, etag=etag, xet_file_data=xet_file_data)
-
-
-def _run_worker_main(request, get_metadata_mock, hf_hub_download_mock=None):
+def _run_worker_main(request, hf_hub_download_mock):
     """Runs core._hf_worker.main() in-process with stdin/stdout swapped for
-    StringIO buffers and huggingface_hub's network-calling functions mocked
-    out. Returns the list of parsed JSON events it emitted."""
+    StringIO buffers and huggingface_hub.hf_hub_download mocked out.
+    Returns the list of parsed JSON events it emitted."""
     from core import _hf_worker as worker
 
     old_stdin, old_stdout = sys.stdin, sys.stdout
     sys.stdin = io.StringIO(json.dumps(request) + "\n")
     sys.stdout = io.StringIO()
     try:
-        patches = [mock.patch('huggingface_hub.get_hf_file_metadata', get_metadata_mock)]
-        if hf_hub_download_mock is not None:
-            patches.append(mock.patch('huggingface_hub.hf_hub_download', hf_hub_download_mock))
-        with contextlib.ExitStack() as stack:
-            for p in patches:
-                stack.enter_context(p)
+        with mock.patch('huggingface_hub.hf_hub_download', hf_hub_download_mock):
             worker.main()
         output = sys.stdout.getvalue()
     finally:
@@ -347,27 +340,23 @@ def _skip_without_huggingface_hub(test_name):
         return True
 
 
-def test_worker_escalates_metadata_fetch_once_on_gated_response_when_fallback_available():
-    if _skip_without_huggingface_hub('test_worker_escalates_metadata_fetch_once_on_gated_response_when_fallback_available'):
+def test_worker_escalates_once_on_gated_response_when_fallback_available():
+    if _skip_without_huggingface_hub('test_worker_escalates_once_on_gated_response_when_fallback_available'):
         return
     from huggingface_hub.errors import HfHubHTTPError
 
     calls = []
 
-    def fake_get_metadata(url, token=None, **kwargs):
-        calls.append(token)
-        if token is False:
-            raise HfHubHTTPError('gated', response=_fake_response(403))
-        return _fake_metadata()  # xet_file_data=None -> classic path
-
     def fake_download(**kwargs):
-        assert kwargs['token'] == 'env-token-value', 'the escalated token must carry through to the download itself'
+        calls.append(kwargs['token'])
+        if kwargs['token'] is False:
+            raise HfHubHTTPError('gated', response=_fake_response(403))
         return '/staging/model.safetensors'
 
     events = _run_worker_main(
         {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
          "token": False, "fallback_token": "env-token-value"},
-        fake_get_metadata, fake_download,
+        fake_download,
     )
 
     assert calls == [False, 'env-token-value'], 'must try anonymous first, only escalate after a 403'
@@ -376,21 +365,21 @@ def test_worker_escalates_metadata_fetch_once_on_gated_response_when_fallback_av
     assert events[-1]["event"] == "done" and events[-1]["path"] == "/staging/model.safetensors"
 
 
-def test_worker_does_not_retry_metadata_without_a_fallback_token():
-    if _skip_without_huggingface_hub('test_worker_does_not_retry_metadata_without_a_fallback_token'):
+def test_worker_does_not_retry_without_a_fallback_token():
+    if _skip_without_huggingface_hub('test_worker_does_not_retry_without_a_fallback_token'):
         return
     from huggingface_hub.errors import HfHubHTTPError
 
     calls = []
 
-    def fake_get_metadata(url, token=None, **kwargs):
-        calls.append(token)
+    def fake_download(**kwargs):
+        calls.append(kwargs['token'])
         raise HfHubHTTPError('gated', response=_fake_response(403))
 
     events = _run_worker_main(
         {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
          "token": False, "fallback_token": None},
-        fake_get_metadata,
+        fake_download,
     )
 
     assert calls == [False], 'no token to fall back to -- must not retry'
@@ -398,15 +387,15 @@ def test_worker_does_not_retry_metadata_without_a_fallback_token():
     assert 'gated' in events[-1]['message'].lower()
 
 
-def test_worker_never_escalates_metadata_when_a_token_was_already_sent():
-    if _skip_without_huggingface_hub('test_worker_never_escalates_metadata_when_a_token_was_already_sent'):
+def test_worker_never_escalates_when_a_token_was_already_sent():
+    if _skip_without_huggingface_hub('test_worker_never_escalates_when_a_token_was_already_sent'):
         return
     from huggingface_hub.errors import HfHubHTTPError
 
     calls = []
 
-    def fake_get_metadata(url, token=None, **kwargs):
-        calls.append(token)
+    def fake_download(**kwargs):
+        calls.append(kwargs['token'])
         raise HfHubHTTPError('unauthorized', response=_fake_response(401))
 
     # "Always send" checkbox path: token is already a real string on the
@@ -415,7 +404,7 @@ def test_worker_never_escalates_metadata_when_a_token_was_already_sent():
     events = _run_worker_main(
         {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
          "token": "already-sent-token", "fallback_token": "env-token-value"},
-        fake_get_metadata,
+        fake_download,
     )
 
     assert calls == ['already-sent-token']
@@ -423,120 +412,74 @@ def test_worker_never_escalates_metadata_when_a_token_was_already_sent():
     assert 'rejected' in events[-1]['message'].lower()
 
 
-def test_worker_non_xet_file_uses_hf_hub_download():
-    if _skip_without_huggingface_hub('test_worker_non_xet_file_uses_hf_hub_download'):
+# --- _ProgressTqdm: the reconstruction/transfer dual-signal shim ----------
+#
+# huggingface_hub's Xet integration drives two different progress signals on
+# whatever tqdm_class it's given -- update() for "reconstruction" bytes
+# (verified + flushed to disk, can lag well behind) and, if the class
+# defines it, update_transfer() for raw network bytes (updates continuously,
+# confirmed empirically to fire ~10x/second). Both count toward the same
+# eventual total, not two different things to add together.
+
+def test_progress_tqdm_uses_whichever_signal_is_further_along():
+    from core._hf_worker import _ProgressTqdm
+
+    bar = _ProgressTqdm(total=1000)
+    bar.update_transfer(300)   # network races ahead
+    assert bar.n == 300
+    bar.update(100)            # reconstruction still behind -- must not win
+    assert bar.n == 300
+    bar.update(250)            # reconstruction catches up and passes
+    assert bar.n == 350
+    bar.update_transfer(700)   # network finishes
+    assert bar.n == 1000
+
+
+def test_progress_tqdm_never_double_counts_both_signals():
+    from core._hf_worker import _ProgressTqdm
+
+    bar = _ProgressTqdm(total=1000)
+    for _ in range(10):
+        bar.update_transfer(100)  # network reaches the full total...
+    for _ in range(10):
+        bar.update(100)           # ...then reconstruction catches up to the same total
+    assert bar.n == 1000, 'reconstruction and transfer both approach the same total -- must not sum to 2000'
+
+
+def test_progress_tqdm_works_when_update_transfer_is_never_called():
+    # Older huggingface_hub versions that don't know about the dual-bar
+    # contract simply never call update_transfer -- must not regress.
+    from core._hf_worker import _ProgressTqdm
+
+    bar = _ProgressTqdm(total=1000)
+    bar.update(400)
+    bar.update(600)
+    assert bar.n == 1000
+
+
+def test_worker_download_uses_dual_signal_tqdm_class():
+    if _skip_without_huggingface_hub('test_worker_download_uses_dual_signal_tqdm_class'):
         return
 
-    def fake_get_metadata(url, token=None, **kwargs):
-        return _fake_metadata(xet_file_data=None)  # not Xet-hosted
+    captured = {}
 
     def fake_download(**kwargs):
-        assert kwargs['token'] is False
-        return '/staging/plain.safetensors'
+        tqdm_cls = kwargs['tqdm_class']
+        bar = tqdm_cls(total=1000)
+        bar.update_transfer(500)  # exercised here to prove the class hf_hub_download receives supports it
+        captured['n_after_transfer_update'] = bar.n
+        bar.close()
+        return '/staging/model.safetensors'
 
     events = _run_worker_main(
-        {"repo_id": "u/r", "filename": "plain.safetensors", "local_dir": "/staging",
+        {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
          "token": False, "fallback_token": None},
-        fake_get_metadata, fake_download,
+        fake_download,
     )
 
-    assert events[-1]["event"] == "done" and events[-1]["path"] == "/staging/plain.safetensors"
-
-
-def test_worker_xet_path_downloads_and_reports_real_progress():
-    if _skip_without_huggingface_hub('test_worker_xet_path_downloads_and_reports_real_progress'):
-        return
-
-    tmp = tempfile.mkdtemp(prefix='xet_worker_test_')
-    try:
-        xet_data = SimpleNamespace(file_hash='deadbeef', refresh_route='https://example.com/refresh')
-
-        def fake_get_metadata(url, token=None, **kwargs):
-            return _fake_metadata(size=1000, xet_file_data=xet_data)
-
-        class _FakeGroup:
-            """Mirrors the real hf_xet behavior confirmed empirically:
-            nothing lands on disk until wait_to_finish() completes, and
-            progress() returns an increasing sequence across calls."""
-
-            def __init__(self):
-                self._sequence = [0, 400, 1000]
-                self._i = 0
-                self._dest = None
-
-            def start_download_file(self, file_info, dest_path):
-                self._dest = dest_path
-
-            def progress(self):
-                completed = self._sequence[min(self._i, len(self._sequence) - 1)]
-                self._i += 1
-                return SimpleNamespace(total_bytes_completed=completed, total_bytes=1000,
-                                        total_bytes_completion_rate=500.0)
-
-            def wait_to_finish(self):
-                import time as _time
-                _time.sleep(0.35)  # give the 0.3s poll loop at least one real tick
-                with open(self._dest, 'wb') as f:
-                    f.write(b'x' * 1000)
-                return SimpleNamespace(files=1)
-
-        fake_group = _FakeGroup()
-        fake_session = mock.Mock()
-        fake_session.new_file_download_group.return_value = fake_group
-        fake_hf_xet = mock.Mock()
-        fake_hf_xet.XetSession.return_value = fake_session
-        fake_hf_xet.XetFileInfo = lambda hash, file_size=None: SimpleNamespace(hash=hash, file_size=file_size)
-
-        saved_hf_xet = sys.modules.get('hf_xet')
-        sys.modules['hf_xet'] = fake_hf_xet
-        try:
-            with mock.patch('huggingface_hub.utils._xet.refresh_xet_connection_info',
-                             return_value=SimpleNamespace(endpoint='https://cas.example.com',
-                                                           access_token='tok', expiration_unix_epoch=0)):
-                events = _run_worker_main(
-                    {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": tmp,
-                     "token": False, "fallback_token": None},
-                    fake_get_metadata,
-                )
-        finally:
-            if saved_hf_xet is not None:
-                sys.modules['hf_xet'] = saved_hf_xet
-            else:
-                sys.modules.pop('hf_xet', None)
-
-        kinds = [e['event'] for e in events]
-        assert 'done' in kinds
-        progress_events = [e for e in events if e['event'] == 'progress']
-        assert any(e['n'] > 0 for e in progress_events), 'must report real, nonzero progress before completion'
-        done = [e for e in events if e['event'] == 'done'][0]
-        assert os.path.exists(done['path'])
-        assert os.path.getsize(done['path']) == 1000
-    finally:
-        shutil.rmtree(tmp, ignore_errors=True)
-
-
-def test_worker_xet_path_failure_falls_back_to_hf_hub_download():
-    if _skip_without_huggingface_hub('test_worker_xet_path_failure_falls_back_to_hf_hub_download'):
-        return
-
-    xet_data = SimpleNamespace(file_hash='deadbeef', refresh_route='https://example.com/refresh')
-
-    def fake_get_metadata(url, token=None, **kwargs):
-        return _fake_metadata(size=1000, xet_file_data=xet_data)
-
-    def fake_download(**kwargs):
-        return '/staging/fallback.safetensors'
-
-    with mock.patch('huggingface_hub.utils._xet.refresh_xet_connection_info',
-                     side_effect=RuntimeError('xet connection refused')):
-        events = _run_worker_main(
-            {"repo_id": "u/r", "filename": "model.safetensors", "local_dir": "/staging",
-             "token": False, "fallback_token": None},
-            fake_get_metadata, fake_download,
-        )
-
-    assert events[-1]["event"] == "done" and events[-1]["path"] == "/staging/fallback.safetensors"
-    assert any(e['event'] == 'log' and 'falling back' in e.get('message', '') for e in events)
+    assert captured['n_after_transfer_update'] == 500
+    progress_events = [e for e in events if e['event'] == 'progress']
+    assert any(e['n'] == 500 for e in progress_events), 'the transfer-driven progress must reach the parent'
 
 
 if __name__ == '__main__':

--- a/web/linker.js
+++ b/web/linker.js
@@ -846,7 +846,32 @@ class LinkerManagerDialog extends ComfyDialog {
             $el("span.ml-btn-icon", { textContent: "🔗" }),
             $el("span", { textContent: " Auto-Link 100%" })
         ]);
-        
+
+        // Off by default: HuggingFace downloads try anonymously first and only
+        // send a token (from HF_TOKEN / HUGGING_FACE_HUB_TOKEN) if a model turns
+        // out to be gated. Checking this sends it on every HF download from the
+        // start instead, which can help avoid throttling on a fast connection.
+        this.sendTokenCheckbox = $el("label", {
+            style: {
+                display: "flex",
+                alignItems: "center",
+                gap: "6px",
+                fontSize: "12px",
+                color: "var(--ml-text-muted, #999)",
+                cursor: "pointer",
+                marginRight: "auto",
+                userSelect: "none"
+            },
+            title: "Off by default: HuggingFace downloads are anonymous unless a model turns out to be gated. Check this to always send a HuggingFace token (from HF_TOKEN / HUGGING_FACE_HUB_TOKEN) up front, which can help mitigate throttling on a fast connection."
+        }, [
+            $el("input", {
+                type: "checkbox",
+                checked: this.isSendHfTokenEnabled(),
+                onchange: (e) => this.setSendHfTokenEnabled(e.target.checked)
+            }),
+            $el("span", { textContent: "Always send HF token" })
+        ]);
+
         return $el("div.ml-footer", {
             style: {
                 position: "sticky",
@@ -856,9 +881,23 @@ class LinkerManagerDialog extends ComfyDialog {
                 WebkitBackdropFilter: "blur(8px)"
             }
         }, [
+            this.sendTokenCheckbox,
             this.autoResolveButton,
             this.downloadAllButton
         ]);
+    }
+
+    /**
+     * Whether HF downloads should always send an auth token up front rather
+     * than only escalating to one after a gated/401/403 response. Off by
+     * default -- see createFooter().
+     */
+    isSendHfTokenEnabled() {
+        return localStorage.getItem('modelLinker.alwaysSendHfToken') === 'true';
+    }
+
+    setSendHfTokenEnabled(enabled) {
+        localStorage.setItem('modelLinker.alwaysSendHfToken', enabled ? 'true' : 'false');
     }
     
     /**
@@ -2195,7 +2234,8 @@ class LinkerManagerDialog extends ComfyDialog {
                 body: JSON.stringify({
                     url: source.url,
                     filename: filename,
-                    category: category
+                    category: category,
+                    send_hf_token: this.isSendHfTokenEnabled()
                 })
             });
 
@@ -2559,7 +2599,7 @@ class LinkerManagerDialog extends ComfyDialog {
             const response = await api.fetchApi('/model_linker/download', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ url, filename, category })
+                body: JSON.stringify({ url, filename, category, send_hf_token: this.isSendHfTokenEnabled() })
             });
 
             if (!response.ok) {

--- a/web/linker.js
+++ b/web/linker.js
@@ -869,8 +869,10 @@ class LinkerManagerDialog extends ComfyDialog {
                 checked: this.isSendHfTokenEnabled(),
                 onchange: (e) => this.setSendHfTokenEnabled(e.target.checked)
             }),
-            $el("span", { textContent: "Always send HF token" })
+            $el("span", { textContent: "Always send HF token" }),
+            this.hfTokenStatusSpan = $el("span", { textContent: "" })
         ]);
+        this.refreshHfTokenStatus();
 
         return $el("div.ml-footer", {
             style: {
@@ -899,7 +901,31 @@ class LinkerManagerDialog extends ComfyDialog {
     setSendHfTokenEnabled(enabled) {
         localStorage.setItem('modelLinker.alwaysSendHfToken', enabled ? 'true' : 'false');
     }
-    
+
+    /**
+     * Checks whether HF_TOKEN / HUGGING_FACE_HUB_TOKEN is actually set in
+     * the environment ComfyUI is running in, and reflects it next to the
+     * "Always send HF token" checkbox -- so checking the box when nothing
+     * is there to send isn't a silent no-op.
+     */
+    async refreshHfTokenStatus() {
+        if (!this.hfTokenStatusSpan) return;
+        try {
+            const response = await api.fetchApi('/model_linker/hf_token_status');
+            const data = await response.json();
+            if (data.detected) {
+                this.hfTokenStatusSpan.textContent = '(detected)';
+                this.hfTokenStatusSpan.style.color = '#4CAF50';
+            } else {
+                this.hfTokenStatusSpan.textContent = '(not detected)';
+                this.hfTokenStatusSpan.style.color = '#dc3545';
+            }
+        } catch (error) {
+            console.error('Model Linker: Error checking HF token status:', error);
+            this.hfTokenStatusSpan.textContent = '';
+        }
+    }
+
     /**
      * Handle click on Download All / Cancel All button
      */


### PR DESCRIPTION
Greetings!

I have to gush again about how much I love your addon!  It's so useful, especially when spinning up remote instances - being able to provision with one click is a Godsend.  Thank you.

I have composed a modest patch that will use huggingface's hub downloader for cases where we're downloading from hf (which at least for me is like 99% of the time).  There are a couple of advantages with this: hf's downloader is setup for multiple threads and multiple connections, so the downloads can potentially be MUCH faster.  And, naturally, hf's own downloader trivially supports using a PAT/key to access gated models.  This is, unfortunately, becoming ever more common a hurdle.

hf hub is already a prerequisite of comfy, so we don't technically have any extra requirements, though I did take the initiative to update the requirements.txt and pyproject files to avoid being caught out if a future update should drop transformers or whatever.  Not a big deal.

My approach to using the hf auth system mirrors what you were heading towards before: don't send the key unless required.  We query for the presence of a key in the environment variables and show whether or not we detected one alongside a checkbox we've added to the GUI allowing users to opt-in to *always send hf_token* with a descriptive tooltip.  If a key is available via $HF_TOKEN and we are refused a model via gating, we now fall back to sending the key and retrying.  If the checkbox is enabled, we send the key for all hf requests because it, at least in theory and according to scary warnings when you're not logged in, reduces the likelihood of being throttled.
<img width="1920" height="1080" alt="screenshot of updated ui" src="https://github.com/user-attachments/assets/6c481020-0b75-435c-adb5-81b8bde7dca4" />

I have also made some minor changes to the README to explain WHY HF_TOKEN, WHEN HF_TOKEN, HOW HF_TOKEN, etc.

Testing:
I tested the feature branch out locally (<100mb/s) and remotely (on datacenter network).  Discovered that older hb hub versions (eg 1.17) had issues with progress bar updates and worked out a patch that works around it rather than forcing everyone to run bleeding edge.  Worst-case, I expect someone gets infrequent progress bar updates.  It should be in a good place overall and I've made the logging of downloads a bit more verbose.  Download speeds on the pod went from ~100MB/s w/ the original download code to basically cap out the connection with the updated code: `Size: 19.5 GB, Time: 31.0s, Avg speed: 645.4 MB/s`.  A nice uplift, beyond finally being able to one-click Flux-family, new LTX, and other gated models to queue them for download.

Thanks again for your great project - I hope this small contribution lands as intended.

BEst regards,
FNG